### PR TITLE
Hotfix to correct interface check on Validate function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/SafetyCulture/s12-proto
 
 require (
-	github.com/SafetyCulture/s12-proto/protobuf/s12proto v0.0.0-20190116024658-2fe1bfc71930
 	github.com/gofrs/uuid v3.1.0+incompatible
 	github.com/gogo/protobuf v1.2.0
 	github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/SafetyCulture/s12-proto/protobuf/s12proto v0.0.0-20190116024658-2fe1bfc71930 h1:nG1H9i2T2oQTVs/zrH3N5xXBvLRgdoiApv4wvskaNeI=
-github.com/SafetyCulture/s12-proto/protobuf/s12proto v0.0.0-20190116024658-2fe1bfc71930/go.mod h1:QdJVEsOEHmzjfRvYPZS/GEJIeCo1RZiA82mcAwNuC8E=
 github.com/gofrs/uuid v3.1.0+incompatible h1:q2rtkjaKT4YEr6E1kamy0Ha4RtepWlQBedyHx0uzKwA=
 github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
-github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/protobuf/protoc-gen-govalidator/example/example.validator.pb.go
+++ b/protobuf/protoc-gen-govalidator/example/example.validator.pb.go
@@ -43,7 +43,7 @@ func (this *ExampleMessage) Validate() error {
 		return github_com_pkg_errors.Errorf(`Score: value '%v' must be less than or equal to '100'`, this.Score)
 	}
 	if this.Inner != nil {
-		if v, ok := this.Inner.(github_com_SafetyCulture_s12_proto_protobuf_s12proto.Validator); ok {
+		if v, ok := interface{}(this.Inner).(github_com_SafetyCulture_s12_proto_protobuf_s12proto.Validator); ok {
 			if err := v.Validate(); err != nil {
 				return github_com_SafetyCulture_s12_proto_protobuf_s12proto.FieldError("Inner", err)
 			}
@@ -56,6 +56,7 @@ func (this *ExampleMessage) Validate() error {
 	}
 	return nil
 }
+
 func (this *InnerMessage) Validate() error {
 	if _, err := github_com_gofrs_uuid.FromString(this.Id); err != nil {
 		return github_com_pkg_errors.Errorf(`Id: value '%v' must be parsable as a UUID`, this.Id)

--- a/protobuf/protoc-gen-govalidator/plugin/plugin.go
+++ b/protobuf/protoc-gen-govalidator/plugin/plugin.go
@@ -50,7 +50,7 @@ func (p *plugin) Generate(file *generator.FileDescriptor) {
 		}
 		p.generateRegexVars(file, msg)
 		p.generateValidateFunction(file, msg)
-
+		p.P()
 	}
 }
 
@@ -184,7 +184,7 @@ func (p *plugin) generateInnerMessageValidator(variableName string, ccTypeName s
 		variableName = "&(" + variableName + ")"
 	}
 
-	p.P(`if v, ok := `, variableName, `.(`, p.s12protoPkg.Use(), `.Validator); ok {`)
+	p.P(`if v, ok := interface{}(`, variableName, `).(`, p.s12protoPkg.Use(), `.Validator); ok {`)
 	p.In()
 
 	p.P(`if err := v.Validate(); err != nil {`)

--- a/protobuf/s12proto/go.mod
+++ b/protobuf/s12proto/go.mod
@@ -1,3 +1,0 @@
-module github.com/SafetyCulture/s12-proto/protobuf/s12proto
-
-require github.com/gogo/protobuf v1.2.0

--- a/protobuf/s12proto/go.sum
+++ b/protobuf/s12proto/go.sum
@@ -1,2 +1,0 @@
-github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
-github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=


### PR DESCRIPTION
You can only check that an interface is an interface; a struct is not an interface so cast it as an empty interface before checking for the interface.