### PR TITLE
Remove 3rd party package in favour of std lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,4 @@ module github.com/SafetyCulture/s12-proto
 require (
 	github.com/gofrs/uuid v3.1.0+incompatible
 	github.com/gogo/protobuf v1.2.0
-	github.com/pkg/errors v0.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,5 +2,3 @@ github.com/gofrs/uuid v3.1.0+incompatible h1:q2rtkjaKT4YEr6E1kamy0Ha4RtepWlQBedy
 github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/protobuf/protoc-gen-govalidator/example/example.validator.pb.go
+++ b/protobuf/protoc-gen-govalidator/example/example.validator.pb.go
@@ -3,12 +3,11 @@
 
 package example
 
+import fmt "fmt"
 import regexp "regexp"
-import github_com_pkg_errors "github.com/pkg/errors"
 import github_com_gofrs_uuid "github.com/gofrs/uuid"
 import github_com_SafetyCulture_s12_proto_protobuf_s12proto "github.com/SafetyCulture/s12-proto/protobuf/s12proto"
 import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
 import math "math"
 import _ "github.com/SafetyCulture/s12-proto/protobuf/s12proto"
 import _ "github.com/gogo/protobuf/gogoproto"
@@ -22,25 +21,25 @@ var _regex_ExampleMessage_Description = regexp.MustCompile(`^[a-z]{2,5}$`)
 
 func (this *ExampleMessage) Validate() error {
 	if _, err := github_com_gofrs_uuid.FromString(this.Id); err != nil {
-		return github_com_pkg_errors.Errorf(`Id: value '%v' must be parsable as a UUID`, this.Id)
+		return fmt.Errorf(`Id: value '%v' must be parsable as a UUID`, this.Id)
 	}
 	if _, err := github_com_gofrs_uuid.FromBytes(this.UserID); err != nil {
-		return github_com_pkg_errors.Errorf(`UserID: value '%v' must be parsable as a UUID`, this.UserID)
+		return fmt.Errorf(`UserID: value '%v' must be parsable as a UUID`, this.UserID)
 	}
 	if !_regex_ExampleMessage_Description.MatchString(this.Description) {
-		return github_com_pkg_errors.Errorf(`Description: value '%v' must be a string conforming to regex "^[a-z]{2,5}$"`, this.Description)
+		return fmt.Errorf(`Description: value '%v' must be a string conforming to regex "^[a-z]{2,5}$"`, this.Description)
 	}
 	if !(this.Age > 0) {
-		return github_com_pkg_errors.Errorf(`Age: value '%v' must be greater than '0'`, this.Age)
+		return fmt.Errorf(`Age: value '%v' must be greater than '0'`, this.Age)
 	}
 	if !(this.Speed < 110) {
-		return github_com_pkg_errors.Errorf(`Speed: value '%v' must be less than '110'`, this.Speed)
+		return fmt.Errorf(`Speed: value '%v' must be less than '110'`, this.Speed)
 	}
 	if !(this.Score >= 0) {
-		return github_com_pkg_errors.Errorf(`Score: value '%v' must be greater than or equal to '0'`, this.Score)
+		return fmt.Errorf(`Score: value '%v' must be greater than or equal to '0'`, this.Score)
 	}
 	if !(this.Score <= 100) {
-		return github_com_pkg_errors.Errorf(`Score: value '%v' must be less than or equal to '100'`, this.Score)
+		return fmt.Errorf(`Score: value '%v' must be less than or equal to '100'`, this.Score)
 	}
 	if this.Inner != nil {
 		if v, ok := interface{}(this.Inner).(github_com_SafetyCulture_s12_proto_protobuf_s12proto.Validator); ok {
@@ -51,7 +50,7 @@ func (this *ExampleMessage) Validate() error {
 	}
 	for _, item := range this.Ids {
 		if _, err := github_com_gofrs_uuid.FromBytes(item); err != nil {
-			return github_com_pkg_errors.Errorf(`Ids: value '%v' must be parsable as a UUID`, item)
+			return fmt.Errorf(`Ids: value '%v' must be parsable as a UUID`, item)
 		}
 	}
 	return nil
@@ -59,7 +58,7 @@ func (this *ExampleMessage) Validate() error {
 
 func (this *InnerMessage) Validate() error {
 	if _, err := github_com_gofrs_uuid.FromString(this.Id); err != nil {
-		return github_com_pkg_errors.Errorf(`Id: value '%v' must be parsable as a UUID`, this.Id)
+		return fmt.Errorf(`Id: value '%v' must be parsable as a UUID`, this.Id)
 	}
 	return nil
 }

--- a/protobuf/protoc-gen-govalidator/plugin/plugin.go
+++ b/protobuf/protoc-gen-govalidator/plugin/plugin.go
@@ -18,7 +18,6 @@ type plugin struct {
 	generator.PluginImports
 	regexPkg    generator.Single
 	fmtPkg      generator.Single
-	errrosPkg   generator.Single
 	uuidPkg     generator.Single
 	s12protoPkg generator.Single
 }
@@ -40,7 +39,6 @@ func (p *plugin) Generate(file *generator.FileDescriptor) {
 	p.PluginImports = generator.NewPluginImports(p.Generator)
 	p.fmtPkg = p.NewImport("fmt")
 	p.regexPkg = p.NewImport("regexp")
-	p.errrosPkg = p.NewImport("github.com/pkg/errors")
 	p.uuidPkg = p.NewImport("github.com/gofrs/uuid")
 	p.s12protoPkg = p.NewImport("github.com/SafetyCulture/s12-proto/protobuf/s12proto")
 
@@ -203,7 +201,7 @@ func (p *plugin) generateInnerMessageValidator(variableName string, ccTypeName s
 }
 
 func (p *plugin) generateErrorString(variableName string, fieldName string, specificError string) {
-	p.P(`return `, p.errrosPkg.Use(), ".Errorf(`", fieldName, `: value '%v' must `, specificError, "`, ", variableName, `)`)
+	p.P(`return `, p.fmtPkg.Use(), ".Errorf(`", fieldName, `: value '%v' must `, specificError, "`, ", variableName, `)`)
 }
 
 func regexName(ccTypeName, fieldName string) string {


### PR DESCRIPTION
There is no benefit to using the `pkg/errors` library; remove to simplify dependancies.