### PR TITLE
[PLT-683] Remove UUID library dependancy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,3 @@
 module github.com/SafetyCulture/s12-proto
 
-require (
-	github.com/gofrs/uuid v3.1.0+incompatible
-	github.com/gogo/protobuf v1.2.0
-)
+require github.com/gogo/protobuf v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/gofrs/uuid v3.1.0+incompatible h1:q2rtkjaKT4YEr6E1kamy0Ha4RtepWlQBedyHx0uzKwA=
-github.com/gofrs/uuid v3.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/protobuf/protoc-gen-govalidator/example/example.validator.pb.go
+++ b/protobuf/protoc-gen-govalidator/example/example.validator.pb.go
@@ -5,7 +5,6 @@ package example
 
 import regexp "regexp"
 import github_com_pkg_errors "github.com/pkg/errors"
-import github_com_gofrs_uuid "github.com/gofrs/uuid"
 import github_com_SafetyCulture_s12_proto_protobuf_s12proto "github.com/SafetyCulture/s12-proto/protobuf/s12proto"
 import proto "github.com/gogo/protobuf/proto"
 import fmt "fmt"
@@ -21,11 +20,11 @@ var _ = math.Inf
 var _regex_ExampleMessage_Description = regexp.MustCompile(`^[a-z]{2,5}$`)
 
 func (this *ExampleMessage) Validate() error {
-	if _, err := github_com_gofrs_uuid.FromString(this.Id); err != nil {
+	if !github_com_SafetyCulture_s12_proto_protobuf_s12proto.IsUUID(this.Id) {
 		return github_com_pkg_errors.Errorf(`Id: value '%v' must be parsable as a UUID`, this.Id)
 	}
-	if _, err := github_com_gofrs_uuid.FromBytes(this.UserID); err != nil {
-		return github_com_pkg_errors.Errorf(`UserID: value '%v' must be parsable as a UUID`, this.UserID)
+	if len(this.UserID) != github_com_SafetyCulture_s12_proto_protobuf_s12proto.UUIDSize {
+		return github_com_pkg_errors.Errorf(`UserID: value '%v' must be exactly 16 bytes long to be a valid UUID`, this.UserID)
 	}
 	if !_regex_ExampleMessage_Description.MatchString(this.Description) {
 		return github_com_pkg_errors.Errorf(`Description: value '%v' must be a string conforming to regex "^[a-z]{2,5}$"`, this.Description)
@@ -50,15 +49,15 @@ func (this *ExampleMessage) Validate() error {
 		}
 	}
 	for _, item := range this.Ids {
-		if _, err := github_com_gofrs_uuid.FromBytes(item); err != nil {
-			return github_com_pkg_errors.Errorf(`Ids: value '%v' must be parsable as a UUID`, item)
+		if len(item) != github_com_SafetyCulture_s12_proto_protobuf_s12proto.UUIDSize {
+			return github_com_pkg_errors.Errorf(`Ids: value '%v' must be exactly 16 bytes long to be a valid UUID`, item)
 		}
 	}
 	return nil
 }
 
 func (this *InnerMessage) Validate() error {
-	if _, err := github_com_gofrs_uuid.FromString(this.Id); err != nil {
+	if !github_com_SafetyCulture_s12_proto_protobuf_s12proto.IsUUID(this.Id) {
 		return github_com_pkg_errors.Errorf(`Id: value '%v' must be parsable as a UUID`, this.Id)
 	}
 	return nil

--- a/protobuf/protoc-gen-govalidator/plugin/plugin.go
+++ b/protobuf/protoc-gen-govalidator/plugin/plugin.go
@@ -19,7 +19,6 @@ type plugin struct {
 	regexPkg    generator.Single
 	fmtPkg      generator.Single
 	errrosPkg   generator.Single
-	uuidPkg     generator.Single
 	s12protoPkg generator.Single
 }
 
@@ -41,7 +40,6 @@ func (p *plugin) Generate(file *generator.FileDescriptor) {
 	p.fmtPkg = p.NewImport("fmt")
 	p.regexPkg = p.NewImport("regexp")
 	p.errrosPkg = p.NewImport("github.com/pkg/errors")
-	p.uuidPkg = p.NewImport("github.com/gofrs/uuid")
 	p.s12protoPkg = p.NewImport("github.com/SafetyCulture/s12-proto/protobuf/s12proto")
 
 	for _, msg := range file.Messages() {
@@ -120,7 +118,7 @@ func (p *plugin) generateStringValidator(variableName string, ccTypeName string,
 		p.P(`}`)
 	}
 	if getUUIDValue(field) {
-		p.P(`if _, err := `, p.uuidPkg.Use(), `.FromString(`, variableName, `); err != nil {`)
+		p.P(`if !`, p.s12protoPkg.Use(), `.IsUUID(`, variableName, `) {`)
 		p.In()
 		errorStr := "be parsable as a UUID"
 		p.generateErrorString(variableName, fieldName, errorStr)
@@ -131,9 +129,9 @@ func (p *plugin) generateStringValidator(variableName string, ccTypeName string,
 
 func (p *plugin) generateBytesValidator(variableName string, ccTypeName string, fieldName string, field *descriptor.FieldDescriptorProto) {
 	if getUUIDValue(field) {
-		p.P(`if _, err := `, p.uuidPkg.Use(), `.FromBytes(`, variableName, `); err != nil {`)
+		p.P(`if len(`, variableName, `) != `, p.s12protoPkg.Use(), `.UUIDSize {`)
 		p.In()
-		errorStr := "be parsable as a UUID"
+		errorStr := "be exactly 16 bytes long to be a valid UUID"
 		p.generateErrorString(variableName, fieldName, errorStr)
 		p.Out()
 		p.P(`}`)

--- a/protobuf/s12proto/validator_helpers.go
+++ b/protobuf/s12proto/validator_helpers.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	// // UUIDSize is the size of a UUID in bytes.
+	// UUIDSize is the size of a UUID in bytes.
 	UUIDSize int = 16
 )
 

--- a/protobuf/s12proto/validator_helpers.go
+++ b/protobuf/s12proto/validator_helpers.go
@@ -2,7 +2,28 @@
 
 package s12proto
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// // UUIDSize is the size of a UUID in bytes.
+	UUIDSize int = 16
+)
+
+const (
+	uuid string = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+var (
+	rxUUID = regexp.MustCompile(uuid)
+)
+
+// IsUUID checks if the string is a UUID (version 3, 4 or 5).
+func IsUUID(str string) bool {
+	return rxUUID.MatchString(str)
+}
 
 type Validator interface {
 	Validate() error


### PR DESCRIPTION
A simple regex is simpler and can remove the need for the dependancy.

For validation of the `bytes` for validation as a uuid does the same check as the library:
https://github.com/gofrs/uuid/blob/abfe1881e60ef34074c1b8d8c63b42565c356ed6/codec.go#L206