### PR TITLE
Update main to use already implemented gogo methods

### DIFF
--- a/protobuf/protoc-gen-gogrpcmock/main.go
+++ b/protobuf/protoc-gen-gogrpcmock/main.go
@@ -3,57 +3,12 @@
 package main
 
 import (
-	"io/ioutil"
-	"log"
-	"os"
-	"strings"
-
 	"github.com/SafetyCulture/s12-proto/protobuf/protoc-gen-gogrpcmock/plugin"
-	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
+	"github.com/gogo/protobuf/vanity/command"
 )
 
 func main() {
-	gen := generator.New()
-	data, err := ioutil.ReadAll(os.Stdin)
-	if err != nil {
-		gen.Error(err, "gogrpcmock: reading input")
-	}
-	if err := proto.Unmarshal(data, gen.Request); err != nil {
-		gen.Error(err, "gogrpcmock: parsing input proto")
-	}
-
-	filesToGenerate := make([]string, 0, len(gen.Request.ProtoFile))
-	for _, file := range gen.Request.ProtoFile {
-		if len(file.Service) > 0 {
-			filesToGenerate = append(filesToGenerate, *file.Name)
-		}
-	}
-	gen.Request.FileToGenerate = filesToGenerate
-
-	if len(gen.Request.FileToGenerate) == 0 {
-		log.Println("gogrpcmock: no files to generate")
-		return
-	}
-
-	gen.CommandLineParameters(gen.Request.GetParameter())
-	gen.WrapTypes()
-	gen.SetPackageNames()
-	gen.BuildTypeNameMap()
-
-	gen.GeneratePlugin(plugin.New())
-
-	for i := 0; i < len(gen.Response.File); i++ {
-		gen.Response.File[i].Name = proto.String(strings.Replace(*gen.Response.File[i].Name, ".pb.go", ".mock.go", -1))
-	}
-
-	data, err = proto.Marshal(gen.Response)
-	if err != nil {
-		gen.Error(err, "gogrpcmock: failed to marshal output proto")
-	}
-
-	_, err = os.Stdout.Write(data)
-	if err != nil {
-		gen.Error(err, "gogrpcmock: failed to write output proto")
-	}
+	req := command.Read()
+	resp := command.GeneratePlugin(req, plugin.New(), ".mock.go")
+	command.Write(resp)
 }


### PR DESCRIPTION
This fixes errors like:
```
protoc-gen-gogo: error:inconsistent package import paths: "protos/a", "protos/b"
--gogrpcmock_out: protoc-gen-gogrpcmock: Plugin failed with status code 1.
```

that happen because `protos/b` imports `protos/a`