### PR TITLE
PS-482 Update code generator for crux api

### DIFF
--- a/protobuf/protoc-gen-cruxclient/api_generator.cc
+++ b/protobuf/protoc-gen-cruxclient/api_generator.cc
@@ -205,6 +205,7 @@ void APIGenerator::PrintSourceAPIs(
     const ServiceDescriptor *service = file->service(service_index);
     vars["service_name"] = service->name();
     vars["service_fullname"] = DotsToColons(service->full_name());
+    vars["service_fullname_underscore"] = DotsToUnderscores(service->full_name());
 
     printer->Print(vars, "namespace $service_name${\n");
     for (int method_index = 0; method_index < service->method_count();
@@ -229,7 +230,19 @@ void APIGenerator::PrintSourceAPIs(
 
       printer->Print(vars, "std::string $api_name$::Name() const {\n");
       printer->Indent();
-      printer->Print(vars, "return \"$service_name$_$method_name$\";\n");
+      printer->Print(vars, "return \"$service_fullname_underscore$_$method_name$\";\n");
+      printer->Outdent();
+      printer->Print("}\n\n");
+
+      printer->Print(vars, "std::string $api_name$::ServiceName() const {\n");
+      printer->Indent();
+      printer->Print(vars, "return \"$service_fullname_underscore$\";\n");
+      printer->Outdent();
+      printer->Print("}\n\n");
+
+      printer->Print(vars, "std::string $api_name$::MethodName() const {\n");
+      printer->Indent();
+      printer->Print(vars, "return \"$method_name$\";\n");
       printer->Outdent();
       printer->Print("}\n\n");
 

--- a/protobuf/protoc-gen-cruxclient/api_generator.h
+++ b/protobuf/protoc-gen-cruxclient/api_generator.h
@@ -39,9 +39,6 @@ class APIGenerator {
   void PrintHeaderIncludes(
     google::protobuf::io::Printer *printer,
     const google::protobuf::FileDescriptor *file) const;
-  void PrintHeaderInterface(
-    google::protobuf::io::Printer *printer,
-    const google::protobuf::FileDescriptor *file) const;
   void PrintHeaderAPIs(
     google::protobuf::io::Printer *printer,
     const google::protobuf::FileDescriptor *file) const;

--- a/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.cc
+++ b/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.cc
@@ -7,7 +7,7 @@
 namespace routeguide::v1 {
 
 namespace RouteGuide{
-GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider) {
+GetFeatureAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider) {
   mStub = routeguide::v1::RouteGuide::NewStub(provider->ConnectionChannel());
 }
 
@@ -30,7 +30,7 @@ grpc::Status GetFeatureAPI::Execute(
   return mStub->GetFeature(context, request, response);
 }
 
-UpdateFeatureAPI(const std::shared_ptr<ChannelProvider>& provider) {
+UpdateFeatureAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider) {
   mStub = routeguide::v1::RouteGuide::NewStub(provider->ConnectionChannel());
 }
 
@@ -53,7 +53,7 @@ grpc::Status UpdateFeatureAPI::Execute(
   return mStub->UpdateFeature(context, request, response);
 }
 
-ListFeaturesAPI(const std::shared_ptr<ChannelProvider>& provider) {
+ListFeaturesAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider) {
   mStub = routeguide::v1::RouteGuide::NewStub(provider->ConnectionChannel());
 }
 
@@ -79,7 +79,7 @@ grpc::Status ListFeaturesAPI::Execute(
 }  // namespace RouteGuide
 
 namespace PublicRouteGuide{
-GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider) {
+GetFeatureAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider) {
   mStub = routeguide::v1::PublicRouteGuide::NewStub(provider->ConnectionChannel());
 }
 

--- a/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.cc
+++ b/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.cc
@@ -12,7 +12,15 @@ GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider) {
 }
 
 std::string GetFeatureAPI::Name() const {
-  return "RouteGuide_GetFeature";
+  return "routeguide_v1_RouteGuide_GetFeature";
+}
+
+std::string GetFeatureAPI::ServiceName() const {
+  return "routeguide_v1_RouteGuide";
+}
+
+std::string GetFeatureAPI::MethodName() const {
+  return "GetFeature";
 }
 
 grpc::Status GetFeatureAPI::Execute(
@@ -27,7 +35,15 @@ UpdateFeatureAPI(const std::shared_ptr<ChannelProvider>& provider) {
 }
 
 std::string UpdateFeatureAPI::Name() const {
-  return "RouteGuide_UpdateFeature";
+  return "routeguide_v1_RouteGuide_UpdateFeature";
+}
+
+std::string UpdateFeatureAPI::ServiceName() const {
+  return "routeguide_v1_RouteGuide";
+}
+
+std::string UpdateFeatureAPI::MethodName() const {
+  return "UpdateFeature";
 }
 
 grpc::Status UpdateFeatureAPI::Execute(
@@ -42,7 +58,15 @@ ListFeaturesAPI(const std::shared_ptr<ChannelProvider>& provider) {
 }
 
 std::string ListFeaturesAPI::Name() const {
-  return "RouteGuide_ListFeatures";
+  return "routeguide_v1_RouteGuide_ListFeatures";
+}
+
+std::string ListFeaturesAPI::ServiceName() const {
+  return "routeguide_v1_RouteGuide";
+}
+
+std::string ListFeaturesAPI::MethodName() const {
+  return "ListFeatures";
 }
 
 grpc::Status ListFeaturesAPI::Execute(
@@ -60,7 +84,15 @@ GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider) {
 }
 
 std::string GetFeatureAPI::Name() const {
-  return "PublicRouteGuide_GetFeature";
+  return "routeguide_v1_PublicRouteGuide_GetFeature";
+}
+
+std::string GetFeatureAPI::ServiceName() const {
+  return "routeguide_v1_PublicRouteGuide";
+}
+
+std::string GetFeatureAPI::MethodName() const {
+  return "GetFeature";
 }
 
 grpc::Status GetFeatureAPI::Execute(
@@ -74,4 +106,3 @@ grpc::Status GetFeatureAPI::Execute(
 
 
 }  // namespace routeguide::v1
-

--- a/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.h
+++ b/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.h
@@ -18,10 +18,62 @@ class ChannelProvider {
 };
 
 namespace RouteGuide {
+template<typename RESPONSE>
+grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& request_data, const std::string& method_name, RESPONSE* response) {
+  if (method_name == "GetFeature") {
+    routeguide::v1::Point request;
+    if (!request_data.UnpackTo(&request)) {
+      return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
+    }
+    GetFeatureAPI api = GetFeatureAPI();
+    return api.Execute(context, request, response);
+  }
+
+  if (method_name == "UpdateFeature") {
+    routeguide::v1::Point request;
+    if (!request_data.UnpackTo(&request)) {
+      return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
+    }
+    UpdateFeatureAPI api = UpdateFeatureAPI();
+    return api.Execute(context, request, response);
+  }
+
+  if (method_name == "ListFeatures") {
+    routeguide::v1::Rectangle request;
+    if (!request_data.UnpackTo(&request)) {
+      return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
+    }
+    ListFeaturesAPI api = ListFeaturesAPI();
+    return api.Execute(context, request, response);
+  }
+
+  if (method_name == "RecordRoute") {
+    routeguide::v1::Point request;
+    if (!request_data.UnpackTo(&request)) {
+      return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
+    }
+    RecordRouteAPI api = RecordRouteAPI();
+    return api.Execute(context, request, response);
+  }
+
+  if (method_name == "RouteChat") {
+    routeguide::v1::RouteNote request;
+    if (!request_data.UnpackTo(&request)) {
+      return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
+    }
+    RouteChatAPI api = RouteChatAPI();
+    return api.Execute(context, request, response);
+  }
+
+  return grpc::Status(grpc::StatusCode::DATA_LOSS, "Invalid method name");
+}
+
 class GetFeatureAPI {
  public:
   explicit GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider);
   std::string Name() const;
+  std::string ServiceName() const;
+  std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Point& request,
@@ -34,6 +86,8 @@ class UpdateFeatureAPI {
  public:
   explicit UpdateFeatureAPI(const std::shared_ptr<ChannelProvider>& provider);
   std::string Name() const;
+  std::string ServiceName() const;
+  std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Point& request,
@@ -46,6 +100,8 @@ class ListFeaturesAPI {
  public:
   explicit ListFeaturesAPI(const std::shared_ptr<ChannelProvider>& provider);
   std::string Name() const;
+  std::string ServiceName() const;
+  std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Rectangle& request,
@@ -57,10 +113,26 @@ class ListFeaturesAPI {
 }  // namespace RouteGuide
 
 namespace PublicRouteGuide {
+template<typename RESPONSE>
+grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& request_data, const std::string& method_name, RESPONSE* response) {
+  if (method_name == "GetFeature") {
+    routeguide::v1::Point request;
+    if (!request_data.UnpackTo(&request)) {
+      return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
+    }
+    GetFeatureAPI api = GetFeatureAPI();
+    return api.Execute(context, request, response);
+  }
+
+  return grpc::Status(grpc::StatusCode::DATA_LOSS, "Invalid method name");
+}
+
 class GetFeatureAPI {
  public:
   explicit GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider);
   std::string Name() const;
+  std::string ServiceName() const;
+  std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Point& request,

--- a/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.h
+++ b/protobuf/protoc-gen-cruxclient/example/route_guide.crux.api.h
@@ -9,23 +9,19 @@
 
 #include <google/protobuf/any.pb.h>
 #include "route_guide.grpc.pb.h"
+#include "crux_engine_client_support.h"
 
 namespace routeguide::v1 {
 
-class ChannelProvider {
- public:
-  virtual std::shared_ptr<grpc::Channel> ConnectionChannel() const = 0;
-};
-
 namespace RouteGuide {
 template<typename RESPONSE>
-grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& request_data, const std::string& method_name, RESPONSE* response) {
+grpc::Status Invoke(const std::shared_ptr<crux::engine::ChannelProvider>& provider, grpc::ClientContext* context, const google::protobuf::Any& request_data, const std::string& method_name, RESPONSE* response) {
   if (method_name == "GetFeature") {
     routeguide::v1::Point request;
     if (!request_data.UnpackTo(&request)) {
       return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
     }
-    GetFeatureAPI api = GetFeatureAPI();
+    GetFeatureAPI api = GetFeatureAPI(provider);
     return api.Execute(context, request, response);
   }
 
@@ -34,7 +30,7 @@ grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& r
     if (!request_data.UnpackTo(&request)) {
       return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
     }
-    UpdateFeatureAPI api = UpdateFeatureAPI();
+    UpdateFeatureAPI api = UpdateFeatureAPI(provider);
     return api.Execute(context, request, response);
   }
 
@@ -43,7 +39,7 @@ grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& r
     if (!request_data.UnpackTo(&request)) {
       return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
     }
-    ListFeaturesAPI api = ListFeaturesAPI();
+    ListFeaturesAPI api = ListFeaturesAPI(provider);
     return api.Execute(context, request, response);
   }
 
@@ -52,7 +48,7 @@ grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& r
     if (!request_data.UnpackTo(&request)) {
       return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
     }
-    RecordRouteAPI api = RecordRouteAPI();
+    RecordRouteAPI api = RecordRouteAPI(provider);
     return api.Execute(context, request, response);
   }
 
@@ -61,7 +57,7 @@ grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& r
     if (!request_data.UnpackTo(&request)) {
       return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
     }
-    RouteChatAPI api = RouteChatAPI();
+    RouteChatAPI api = RouteChatAPI(provider);
     return api.Execute(context, request, response);
   }
 
@@ -70,10 +66,10 @@ grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& r
 
 class GetFeatureAPI {
  public:
-  explicit GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider);
-  std::string Name() const;
-  std::string ServiceName() const;
-  std::string MethodName() const;
+  explicit GetFeatureAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider);
+  static std::string Name() const;
+  static std::string ServiceName() const;
+  static std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Point& request,
@@ -84,10 +80,10 @@ class GetFeatureAPI {
 
 class UpdateFeatureAPI {
  public:
-  explicit UpdateFeatureAPI(const std::shared_ptr<ChannelProvider>& provider);
-  std::string Name() const;
-  std::string ServiceName() const;
-  std::string MethodName() const;
+  explicit UpdateFeatureAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider);
+  static std::string Name() const;
+  static std::string ServiceName() const;
+  static std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Point& request,
@@ -98,10 +94,10 @@ class UpdateFeatureAPI {
 
 class ListFeaturesAPI {
  public:
-  explicit ListFeaturesAPI(const std::shared_ptr<ChannelProvider>& provider);
-  std::string Name() const;
-  std::string ServiceName() const;
-  std::string MethodName() const;
+  explicit ListFeaturesAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider);
+  static std::string Name() const;
+  static std::string ServiceName() const;
+  static std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Rectangle& request,
@@ -114,13 +110,13 @@ class ListFeaturesAPI {
 
 namespace PublicRouteGuide {
 template<typename RESPONSE>
-grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& request_data, const std::string& method_name, RESPONSE* response) {
+grpc::Status Invoke(const std::shared_ptr<crux::engine::ChannelProvider>& provider, grpc::ClientContext* context, const google::protobuf::Any& request_data, const std::string& method_name, RESPONSE* response) {
   if (method_name == "GetFeature") {
     routeguide::v1::Point request;
     if (!request_data.UnpackTo(&request)) {
       return grpc::Status(grpc::StatusCode::DATA_LOSS, "Unable to unpack the request data");
     }
-    GetFeatureAPI api = GetFeatureAPI();
+    GetFeatureAPI api = GetFeatureAPI(provider);
     return api.Execute(context, request, response);
   }
 
@@ -129,10 +125,10 @@ grpc::Status Invoke(grpc::ClientContext* context, const google::protobuf::Any& r
 
 class GetFeatureAPI {
  public:
-  explicit GetFeatureAPI(const std::shared_ptr<ChannelProvider>& provider);
-  std::string Name() const;
-  std::string ServiceName() const;
-  std::string MethodName() const;
+  explicit GetFeatureAPI(const std::shared_ptr<crux::engine::ChannelProvider>& provider);
+  static std::string Name() const;
+  static std::string ServiceName() const;
+  static std::string MethodName() const;
   grpc::Status Execute(
     grpc::ClientContext* context,
     const routeguide::v1::Point& request,


### PR DESCRIPTION
Update code gen for crux API so it can be used by mutation support.

1. Add a service level Invoke method which parses the request data based on method name and invoke the correct API.
1. Add names to each API
1. Remove ChannelProvider interface from this code gen, this should be provided by crux engin.