### PR TITLE
PS-941 Free the allocated memory

### DIFF
--- a/protobuf/protoc-gen-cruxclient/api_generator.cc
+++ b/protobuf/protoc-gen-cruxclient/api_generator.cc
@@ -510,6 +510,7 @@ void APIGenerator::PrintDjinniObjcSupport(
     printer->Print("void *bytes = malloc(byte_size);\n");
     printer->Print("message.SerializeToArray(bytes, static_cast<int>(byte_size));\n");
     printer->Print("NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];\n");
+    printer->Print("free(bytes);\n");
     printer->Print("NSError *error;\n");
     printer->Print(vars, "return [$objc_class_prefix$$message_name$ parseFromData:data error:&error];\n");
     printer->Outdent();

--- a/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.objc.h
+++ b/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.objc.h
@@ -24,6 +24,7 @@ struct Translator {
     void *bytes = malloc(byte_size);
     message.SerializeToArray(bytes, static_cast<int>(byte_size));
     NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];
+    free(bytes);
     NSError *error;
     return [RTGPoint parseFromData:data error:&error];
   }
@@ -54,6 +55,7 @@ struct Translator {
     void *bytes = malloc(byte_size);
     message.SerializeToArray(bytes, static_cast<int>(byte_size));
     NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];
+    free(bytes);
     NSError *error;
     return [RTGRectangle parseFromData:data error:&error];
   }
@@ -84,6 +86,7 @@ struct Translator {
     void *bytes = malloc(byte_size);
     message.SerializeToArray(bytes, static_cast<int>(byte_size));
     NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];
+    free(bytes);
     NSError *error;
     return [RTGFeature parseFromData:data error:&error];
   }
@@ -114,6 +117,7 @@ struct Translator {
     void *bytes = malloc(byte_size);
     message.SerializeToArray(bytes, static_cast<int>(byte_size));
     NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];
+    free(bytes);
     NSError *error;
     return [RTGRouteNote parseFromData:data error:&error];
   }
@@ -144,6 +148,7 @@ struct Translator {
     void *bytes = malloc(byte_size);
     message.SerializeToArray(bytes, static_cast<int>(byte_size));
     NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];
+    free(bytes);
     NSError *error;
     return [RTGRouteSummary parseFromData:data error:&error];
   }
@@ -174,6 +179,7 @@ struct Translator {
     void *bytes = malloc(byte_size);
     message.SerializeToArray(bytes, static_cast<int>(byte_size));
     NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];
+    free(bytes);
     NSError *error;
     return [RTGRouteSummary_Details parseFromData:data error:&error];
   }
@@ -204,6 +210,7 @@ struct Translator {
     void *bytes = malloc(byte_size);
     message.SerializeToArray(bytes, static_cast<int>(byte_size));
     NSData *data = [NSData dataWithBytes: bytes length: (int)byte_size];
+    free(bytes);
     NSError *error;
     return [RTGRouteSummary_Details_MoreDetails parseFromData:data error:&error];
   }


### PR DESCRIPTION
The generated code for passing protobuf message from c++ to objective-C contains memory leaks. The allocated memory malloc is not released after it’s used.

A `free()` needs to be used before return.

This fix has been verified working in the iAuditor using the Instrument tool to profile the app.