### PR TITLE
add implementation to generate a unary interceptor for permissions

### DIFF
--- a/protobuf/protoc-gen-s12perm/plugin/plugin.go
+++ b/protobuf/protoc-gen-s12perm/plugin/plugin.go
@@ -3,6 +3,9 @@
 package plugin
 
 import (
+	"fmt"
+	"strings"
+
 	perms "github.com/SafetyCulture/s12-proto/protobuf/s12proto"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
@@ -11,6 +14,13 @@ import (
 
 type s12perm struct {
 	*generator.Generator
+
+	imports generator.PluginImports
+
+	ctxPkg   generator.Single
+	logPkg   generator.Single
+	grpcPkg  generator.Single
+	utilsPkg generator.Single
 }
 
 func New() generator.Plugin {
@@ -25,30 +35,68 @@ func (g *s12perm) Init(gen *generator.Generator) {
 	g.Generator = gen
 }
 
+func (g *s12perm) GenerateImports(file *generator.FileDescriptor) {
+	if len(file.FileDescriptorProto.Service) == 0 {
+		return
+	}
+	g.imports.GenerateImports(file)
+}
+
 func (g *s12perm) Generate(file *generator.FileDescriptor) {
 	if len(file.FileDescriptorProto.Service) == 0 {
 		return
 	}
 
+	g.imports = generator.NewPluginImports(g.Generator)
+	g.logPkg = g.imports.NewImport("log")
+	g.ctxPkg = g.imports.NewImport("context")
+	g.utilsPkg = g.imports.NewImport("github.com/SafetyCulture/s12-utils-go/utils")
+	g.grpcPkg = g.imports.NewImport("google.golang.org/grpc")
+
 	for _, service := range file.FileDescriptorProto.Service {
+		g.P("func ", service.GetName(), "PermissionsUnaryInterceptor() ", g.grpcPkg.Use(), ".UnaryServerInterceptor {")
+		g.In()
+		g.P("return func(ctx ", g.ctxPkg.Use(), ".Context, req interface{}, info *", g.grpcPkg.Use(), ".UnaryServerInfo, handler ", g.grpcPkg.Use(), ".UnaryHandler) (interface{}, error) {")
+		g.In()
+		g.P("claims, _ := ctx.Value(", g.utilsPkg.Use(), ".ContextKeyS12JWTClaims).(", g.utilsPkg.Use(), ".S12JWTClaims)")
+		g.P("_ = claims")
+
 		for _, method := range service.Method {
+			if method.GetServerStreaming() || method.GetClientStreaming() {
+				// TODO: [RC] create streaming interceptor.
+				continue
+			}
 			flags := getPermissions(method)
 			if len(flags) == 0 {
 				continue
 			}
-			g.P("// Permissions found!")
+			g.P("if info.FullMethod == \"/", file.GetPackage(), ".", service.GetName(), "/", method.GetName(), "\" {")
+			g.In()
 
+			var perms []string
+			for _, perm := range flags {
+				perms = append(perms, fmt.Sprintf("%s.Permission(%q)", g.utilsPkg.Use(), perm))
+			}
+			g.P("if !claims.HasPermission(", strings.Join(perms, ", "), ") {")
+			g.In()
+
+			g.P(g.logPkg.Use(), ".Println(\"s12perm: claims does contain the required permissions\")")
+			g.P("return ctx, ", g.utilsPkg.Use(), ".ErrPermissionDenied")
+
+			g.Out()
+			g.P("}")
+
+			g.Out()
+			g.P("}\n")
 		}
+
+		g.P("return handler(ctx, req)")
+		g.Out()
+		g.P("}")
+		g.Out()
+		g.P("}")
 	}
 
-}
-
-func (g *s12perm) GenerateImports(file *generator.FileDescriptor) {
-	if len(file.FileDescriptorProto.Service) == 0 {
-		return
-	}
-	imports := generator.NewPluginImports(g.Generator)
-	imports.GenerateImports(file)
 }
 
 func getPermissions(method *descriptor.MethodDescriptorProto) []string {


### PR DESCRIPTION
Given this proto file:
```proto
service ActionsService {
  rpc CountActions(CountActionsRequest) returns (CountActionsResponse) {
    option (s12.flags.permissions.required_flags) = "read:users";
    option (google.api.http) = {
      get: "/actions/v1/items/count"
    };
  }
}
```
would generate the following Go code
```go
// Code generated by protoc-gen-gogo. DO NOT EDIT.
// source: s12/actions/v1/actions.proto

package actions

import (
	fmt "fmt"
	math "math"
	proto "github.com/gogo/protobuf/proto"
	golang_proto "github.com/golang/protobuf/proto"
	_ "github.com/SafetyCulture/s12-apis-go/flags/permissions"
	_ "google.golang.org/genproto/googleapis/api/annotations"
	_ "github.com/golang/protobuf/ptypes/timestamp"
	_ "github.com/gogo/protobuf/gogoproto"
	_ "github.com/SafetyCulture/s12-apis-go/common"
	_ "github.com/SafetyCulture/s12-apis-go/flags/crux"
	_ "github.com/SafetyCulture/s12-proto/protobuf/s12proto"
	_ "github.com/golang/protobuf/ptypes/empty"
	log "log"
	context "context"
	github_com_SafetyCulture_s12_utils_go_utils "github.com/SafetyCulture/s12-utils-go/utils"
	google_golang_org_grpc "google.golang.org/grpc"
)

// Reference imports to suppress errors if they are not otherwise used.
var _ = proto.Marshal
var _ = golang_proto.Marshal
var _ = fmt.Errorf
var _ = math.Inf

func ActionsServicePermissionsUnaryInterceptor() google_golang_org_grpc.UnaryServerInterceptor {
	return func(ctx context.Context, req interface{}, info *google_golang_org_grpc.UnaryServerInfo, handler google_golang_org_grpc.UnaryHandler) (interface{}, error) {
		claims, _ := ctx.Value(github_com_SafetyCulture_s12_utils_go_utils.ContextKeyS12JWTClaims).(github_com_SafetyCulture_s12_utils_go_utils.S12JWTClaims)
		_ = claims
		if info.FullMethod == "/s12.actions.v1.ActionsService/CountActions" {
			if !claims.HasPermission(github_com_SafetyCulture_s12_utils_go_utils.Permission("read:users")) {
				log.Println("s12perm: claims does contain the required permissions")
				return ctx, github_com_SafetyCulture_s12_utils_go_utils.ErrPermissionDenied
			}
		}

		return handler(ctx, req)
	}
}
func EvidenceServicePermissionsUnaryInterceptor() google_golang_org_grpc.UnaryServerInterceptor {
	return func(ctx context.Context, req interface{}, info *google_golang_org_grpc.UnaryServerInfo, handler google_golang_org_grpc.UnaryHandler) (interface{}, error) {
		claims, _ := ctx.Value(github_com_SafetyCulture_s12_utils_go_utils.ContextKeyS12JWTClaims).(github_com_SafetyCulture_s12_utils_go_utils.S12JWTClaims)
		_ = claims
		return handler(ctx, req)
	}
}
```

This can then be called from the list of interceptors of your service:

```go
func main() {
    grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
        grpc_auth.UnaryServerInterceptor(s12_auth.JWTAuthFunc(JWTSigningKey)),
        actions.ActionsServicePermissionsUnaryInterceptor(),
    )
}
```
