### PR TITLE
PS-965 Fix the boxed java class name

### DIFF
--- a/protobuf/protoc-gen-cruxclient/api_generator.cc
+++ b/protobuf/protoc-gen-cruxclient/api_generator.cc
@@ -402,6 +402,7 @@ void APIGenerator::PrintDjinniYAML(
   for (const auto message : messages) {
     vars["message_name"] = ClassName(message, false);
     vars["java_message_name"] = UnderscoresToDollar(vars["message_name"]);
+    vars["java_message_box_name"] = UnderscoresToDots(vars["message_name"]);
     vars["cpp_type_name"] = DotsToColons(message->full_name());
     vars["objc_header"] = DotsToSlashs(message->full_name());
     vars["file_name"] = StripProto(file->name());
@@ -444,7 +445,7 @@ void APIGenerator::PrintDjinniYAML(
     printer->Print("java:\n");
     printer->Indent();
     printer->Print(vars, "typename: '$java_package$.$java_message_name$'\n");
-    printer->Print(vars, "boxed: '$java_package$.$java_message_name$'\n");
+    printer->Print(vars, "boxed: '$java_package$.$java_message_box_name$'\n");
     printer->Print("reference: true\n");
     printer->Print("generic: false\n");
     printer->Print("hash: '%s.hashCode()'\n");

--- a/protobuf/protoc-gen-cruxclient/common.h
+++ b/protobuf/protoc-gen-cruxclient/common.h
@@ -137,6 +137,10 @@ inline std::string UnderscoresToDollar(const std::string &name) {
   return StringReplace(name, "_", "$");
 }
 
+inline std::string UnderscoresToDots(const std::string &name) {
+  return StringReplace(name, "_", ".");
+}
+
 inline std::string ToLower(const std::string &input) {
   std::string output = input;
   std::transform(output.begin(), output.end(), output.begin(),

--- a/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.yaml
+++ b/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.yaml
@@ -169,7 +169,7 @@ objcpp:
   header: '"routeguide/v1/message.djinni.objc.h"'
 java:
   typename: 'io.grpc.examples.routeguide.RouteSummary$Details'
-  boxed: 'io.grpc.examples.routeguide.RouteSummary$Details'
+  boxed: 'io.grpc.examples.routeguide.RouteSummary.Details'
   reference: true
   generic: false
   hash: '%s.hashCode()'
@@ -199,7 +199,7 @@ objcpp:
   header: '"routeguide/v1/message.djinni.objc.h"'
 java:
   typename: 'io.grpc.examples.routeguide.RouteSummary$Details$MoreDetails'
-  boxed: 'io.grpc.examples.routeguide.RouteSummary$Details$MoreDetails'
+  boxed: 'io.grpc.examples.routeguide.RouteSummary.Details.MoreDetails'
   reference: true
   generic: false
   hash: '%s.hashCode()'


### PR DESCRIPTION
The generated Java class name for nested message looks like this

```
com.safetyculture.s12.inspections.v1.GetInspectionsResponse.InspectionsListItem
```

instead of 

```
com.safetyculture.s12.inspections.v1.GetInspectionsResponse$InspectionsListItem
```

The boxed Java class name should not have the `$` sign as the nested message separator. The correct symbol should be `.`.