### PR TITLE
Fix jni generated code

### DIFF
--- a/protobuf/protoc-gen-cruxclient/api_generator.cc
+++ b/protobuf/protoc-gen-cruxclient/api_generator.cc
@@ -588,7 +588,7 @@ void APIGenerator::PrintDjinniJNISupport(
     printer->Print("assert(j != nullptr);\n");
     printer->Print("const auto& data = JniClass<JNIInfo>::get();\n");
     printer->Print("assert(jniEnv->IsInstanceOf(j, data.clazz.get()));\n");
-    printer->Print("jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);\n");
+    printer->Print("jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);\n");
     printer->Print("auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);\n");
     printer->Print("jniExceptionCheck(jniEnv);\n");
     printer->Print("CppType cpp_message;\n");

--- a/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.jni.h
+++ b/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.jni.h
@@ -19,7 +19,7 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);
+    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
     jniExceptionCheck(jniEnv);
     CppType cpp_message;
@@ -60,7 +60,7 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);
+    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
     jniExceptionCheck(jniEnv);
     CppType cpp_message;
@@ -101,7 +101,7 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);
+    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
     jniExceptionCheck(jniEnv);
     CppType cpp_message;
@@ -142,7 +142,7 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);
+    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
     jniExceptionCheck(jniEnv);
     CppType cpp_message;
@@ -183,7 +183,7 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);
+    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
     jniExceptionCheck(jniEnv);
     CppType cpp_message;
@@ -224,7 +224,7 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);
+    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
     jniExceptionCheck(jniEnv);
     CppType cpp_message;
@@ -265,7 +265,7 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jbyte b = jniEnv->CallByteMethod(j, data.method_toBytes);
+    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
     jniExceptionCheck(jniEnv);
     CppType cpp_message;
@@ -287,3 +287,4 @@ struct Translator {
   }
 };
 }  //namespace djinni::routeguide::v1::RouteSummary::Details::MoreDetails
+


### PR DESCRIPTION
In `toCpp` method of Translators,  the `toByteArray` of `AbstractMessageLite` returns a `byte[]` that is an `object`.

So, the correct method to use is `JNIEnv.CallObjectMethod` instead of `JNIEnv.CallByteMethod`.

This PR fixes this code generation.