### PR TITLE
Fix marshaling on JNI from jobject to cpp

### DIFF
--- a/protobuf/protoc-gen-cruxclient/api_generator.cc
+++ b/protobuf/protoc-gen-cruxclient/api_generator.cc
@@ -588,11 +588,13 @@ void APIGenerator::PrintDjinniJNISupport(
     printer->Print("assert(j != nullptr);\n");
     printer->Print("const auto& data = JniClass<JNIInfo>::get();\n");
     printer->Print("assert(jniEnv->IsInstanceOf(j, data.clazz.get()));\n");
-    printer->Print("jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);\n");
+    printer->Print("jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));\n");
     printer->Print("auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);\n");
-    printer->Print("jniExceptionCheck(jniEnv);\n");
+    printer->Print("jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);\n");
     printer->Print("CppType cpp_message;\n");
-    printer->Print("cpp_message.ParseFromArray(&b, byte_len);\n");
+    printer->Print("cpp_message.ParseFromArray(byte, byte_len);\n");
+    printer->Print("jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);\n");
+    printer->Print("jniExceptionCheck(jniEnv);\n");
     printer->Print("return cpp_message;\n");
     printer->Outdent();
     printer->Print("}\n\n");

--- a/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.jni.h
+++ b/protobuf/protoc-gen-cruxclient/generated/routeguide/v1/message.djinni.jni.h
@@ -19,11 +19,13 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
+    jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
-    jniExceptionCheck(jniEnv);
+    jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);
     CppType cpp_message;
-    cpp_message.ParseFromArray(&b, byte_len);
+    cpp_message.ParseFromArray(byte, byte_len);
+    jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);
+    jniExceptionCheck(jniEnv);
     return cpp_message;
   }
 
@@ -60,11 +62,13 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
+    jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
-    jniExceptionCheck(jniEnv);
+    jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);
     CppType cpp_message;
-    cpp_message.ParseFromArray(&b, byte_len);
+    cpp_message.ParseFromArray(byte, byte_len);
+    jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);
+    jniExceptionCheck(jniEnv);
     return cpp_message;
   }
 
@@ -101,11 +105,13 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
+    jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
-    jniExceptionCheck(jniEnv);
+    jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);
     CppType cpp_message;
-    cpp_message.ParseFromArray(&b, byte_len);
+    cpp_message.ParseFromArray(byte, byte_len);
+    jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);
+    jniExceptionCheck(jniEnv);
     return cpp_message;
   }
 
@@ -142,11 +148,13 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
+    jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
-    jniExceptionCheck(jniEnv);
+    jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);
     CppType cpp_message;
-    cpp_message.ParseFromArray(&b, byte_len);
+    cpp_message.ParseFromArray(byte, byte_len);
+    jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);
+    jniExceptionCheck(jniEnv);
     return cpp_message;
   }
 
@@ -183,11 +191,13 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
+    jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
-    jniExceptionCheck(jniEnv);
+    jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);
     CppType cpp_message;
-    cpp_message.ParseFromArray(&b, byte_len);
+    cpp_message.ParseFromArray(byte, byte_len);
+    jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);
+    jniExceptionCheck(jniEnv);
     return cpp_message;
   }
 
@@ -224,11 +234,13 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
+    jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
-    jniExceptionCheck(jniEnv);
+    jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);
     CppType cpp_message;
-    cpp_message.ParseFromArray(&b, byte_len);
+    cpp_message.ParseFromArray(byte, byte_len);
+    jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);
+    jniExceptionCheck(jniEnv);
     return cpp_message;
   }
 
@@ -265,11 +277,13 @@ struct Translator {
     assert(j != nullptr);
     const auto& data = JniClass<JNIInfo>::get();
     assert(jniEnv->IsInstanceOf(j, data.clazz.get()));
-    jobject b = jniEnv->CallObjectMethod(j, data.method_toBytes);
+    jbyteArray byteArray = static_cast<jbyteArray>(jniEnv->CallObjectMethod(j, data.method_toBytes));
     auto byte_len = jniEnv->CallIntMethod(j, data.method_byteSize);
-    jniExceptionCheck(jniEnv);
+    jbyte* byte = jniEnv->GetByteArrayElements(byteArray, NULL);
     CppType cpp_message;
-    cpp_message.ParseFromArray(&b, byte_len);
+    cpp_message.ParseFromArray(byte, byte_len);
+    jniEnv->ReleaseByteArrayElements(byteArray, byte, JNI_ABORT);
+    jniExceptionCheck(jniEnv);
     return cpp_message;
   }
 


### PR DESCRIPTION
In https://github.com/SafetyCulture/s12-proto/pull/58 I've fixed a JNI crash but I didn't realize that the marshaling of the objects was incorrect (the `cpp_message.ParseFromArray(b, byte_len);` was returning `false`).

To correctly use the `ParseFromArray`, we should provide a `jbyte`. So, in this PR I'm converting the `jobject` to a `jbyte*` before use the `ParseFromArray`.

