### PR TITLE
IS-1336 Fix s12perm error message typo

### DIFF
--- a/protobuf/protoc-gen-s12perm/plugin/plugin.go
+++ b/protobuf/protoc-gen-s12perm/plugin/plugin.go
@@ -81,7 +81,7 @@ func genUnaryInterceptor(g *protogen.GeneratedFile, srv *protogen.Service) {
 			perms = append(perms, fmt.Sprintf("%s(%q)", g.QualifiedGoIdent(jwtclaimsPackage.Ident("Permission")), perm))
 		}
 		g.P("if !c.HasPermission(", strings.Join(perms, ", "), ") {")
-		g.P(logPackage.Ident("Println"), "(\"s12perm: claims does contain the required permissions\")")
+		g.P(logPackage.Ident("Println"), "(\"s12perm: claims does not contain the required permissions\")")
 		g.P("return ctx, ", grpcstatusPackage.Ident("Errorf"), "(", grpccodesPackage.Ident("PermissionDenied"), ", ", "\"Permission Denied\"", ")")
 		g.P("}")
 		g.P("}")


### PR DESCRIPTION
The error message when an permission check on an endpoint fails outputs: `2021/10/19 10:49:20 s12perm: claims does contain the required permissions`. This should be does _not_.