### PR TITLE
SEC-2004 Bump max unsafe_string length to 30k bytes

### DIFF
--- a/protobuf/protoc-gen-govalidator/plugin/validation_definitions.go
+++ b/protobuf/protoc-gen-govalidator/plugin/validation_definitions.go
@@ -15,7 +15,7 @@ const (
 	stringLenMinSafe    = uint32(1)
 	stringLenMinUnsafe  = uint32(1) // <1 not allowed, use optional instead of empty strings
 	stringLenMaxSafe    = uint32(1000)
-	stringLenMaxUnsafe  = uint32(10000)
+	stringLenMaxUnsafe  = uint32(30000)
 	stringLenMinDefault = uint32(1)
 	stringLenMaxDefault = uint32(130)
 )

--- a/protobuf/protoc-gen-govalidator/valtest/valtest.proto
+++ b/protobuf/protoc-gen-govalidator/valtest/valtest.proto
@@ -160,6 +160,8 @@ message ValTestMessage {
       optional: true
     }
   ];
+
+  string long_string = 67 [(validator.unsafe_string) = { len: ":30000", optional: true }];
 }
 
 message LogOnlyValidationMessage {

--- a/protobuf/protoc-gen-govalidator/valtest/valtest_test.go
+++ b/protobuf/protoc-gen-govalidator/valtest/valtest_test.go
@@ -121,8 +121,8 @@ var invalidURLs = []string{
 	"https:/example.com",
 	"https//:example.com",
 	"https://example.com/" + strings.Repeat("a", 1000), // too long
-	"ftp://example.com/",             // default scheme is https
-	"https://example.com/a#fragment", // fragment not allowed unless option enabled
+	"ftp://example.com/",                               // default scheme is https
+	"https://example.com/a#fragment",                   // fragment not allowed unless option enabled
 	"https://example.com/\na",
 	" https://example.com/a",  // leading whitespace
 	"\thttps://example.com/a", // leading whitespace
@@ -184,7 +184,8 @@ var valMsg = ValTestMessage{
 	Url:        "https://example.com/test",
 	UrlAllOpts: "http://app.safetyculture.com/report/media?param=test#fragment",
 	// NotSupported: ,
-	Timezone: "Australia/Sydney",
+	Timezone:   "Australia/Sydney",
+	LongString: strings.Repeat("x", 30000),
 }
 
 // omit optional fields here
@@ -390,6 +391,9 @@ func getValMsg(m ValTestMessage) *ValTestMessage {
 	}
 	if m.TimezoneOptional != "" {
 		newMsg.TimezoneOptional = replaceEmpty(m.TimezoneOptional)
+	}
+	if m.LongString != "" {
+		newMsg.LongString = replaceEmpty(m.LongString)
 	}
 	return &newMsg
 }
@@ -1001,6 +1005,12 @@ func TestValidationRules(t *testing.T) {
 		emptyTimezoneMsg,
 		invalid,
 	})
+	tests = append(tests, TestSet{
+		"InvalidLongString",
+		getValMsg(ValTestMessage{LongString: strings.Repeat("y", 30002)}),
+		invalid,
+	})
+	fmt.Println("###### LEN = ", len(strings.Repeat("y", 30002)))
 
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

Extending the maximum string length from 10k to 30k bytes for the `unsafe_string` validator. There is currently a valid use case for a field that can hold more than 10k characters so bumping this to accomodate this otherwise these validators can't be used for the relevant field.
<!-- Short summary of what the PR does -->

## Problem description

<!-- Description of the problem being solved -->

## Pros/cons of approach implemented

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [x] Is this PR a reasonable size?

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
