### PR TITLE
INSPECT-8529: Add test case with +Inf for Number when allow_nan=false

### DIFF
--- a/protobuf/protoc-gen-govalidator/valtest/valtest_test.go
+++ b/protobuf/protoc-gen-govalidator/valtest/valtest_test.go
@@ -1396,6 +1396,17 @@ func TestNumberValidation_Validate(t *testing.T) {
 			invalid,
 		},
 		{
+			"number disallows +Inf when allow_nan is false",
+			func() *NumberMessage {
+				m := genNumberMessage()
+				m.NanDisallowed = math.Inf(0)
+				m.OptionalNoNanValue = math.Inf(0)
+				m.OptionalOnly = math.Inf(0)
+				return m
+			}(),
+			invalid,
+		},
+		{
 			"number disallows nan when optional",
 			func() *NumberMessage {
 				m := genNumberMessage()


### PR DESCRIPTION
This PR highlights an inconsistency between the described behaviour and the actual behaviour.
* in [confluence](https://safetyculture.atlassian.net/wiki/spaces/SEC/pages/2915958845/Number+Validator) the described behaviour is `When false, prevents NaN, **Infinity and -Infinity** as values. Only supported for float or double types`
* this PR adds a test case for Number validator that checks whether `+Inf` is accepted when `allow_nan=false`. The expectation is that an error is raised. However this is not currently the case.

---

NOTE: There is some code missing from the master branch (i.e. compilation error for `ValTestMessage` in valtest.pb.go - `unknown field LongString in struct literal of type ValTestMessage`). Need to use make command before running test (i.e. `make govalidator-valtest`).

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
