### PR TITLE
[UT-5331] When both reject and break url are defined reject takes precedence

### DIFF
--- a/protobuf/protoc-gen-govalidator/plugin/plugin.go
+++ b/protobuf/protoc-gen-govalidator/plugin/plugin.go
@@ -41,7 +41,7 @@ var regexGeneratedFile *protogen.GeneratedFile
 var regexHashLib = make(map[string]struct{})
 
 // Validator plugin version
-var validatorVersion = "v2.7.0"
+var validatorVersion = "v2.7.1"
 
 // Write a preamble in the auto generated files
 func genGeneratedHeader(gen *protogen.Plugin, g *protogen.GeneratedFile, f *protogen.File) {

--- a/protobuf/protoc-gen-govalidator/plugin/plugin.go
+++ b/protobuf/protoc-gen-govalidator/plugin/plugin.go
@@ -417,6 +417,13 @@ func genStringValidator(g *protogen.GeneratedFile, f *protogen.Field, varName st
 		prepareRegex(allowListReId, `\x{FFFD}`)
 	}
 
+	// If the text contains a full URL anywhere in it, reject it. This should help us control spam.
+	if rules.GetRejectUrl() {
+		g.P("if ", s12protoPackage.Ident("RejectURLMatcher"), ".MatchString(", varName, ") {")
+		genErrorStringWithParams(g, varName, string(f.Desc.Name()), "not contain a URL")
+		g.P("}")
+	}
+
 	// ### STEP 3: sanitise
 	// #### 3A-1. 'Break' partial URLs by introducing a space after each dot between characters.
 	// Note this will PERMANENTLY mutate the message field data. Further iterations will ignore these '. ' patterns,
@@ -538,13 +545,6 @@ func genStringValidator(g *protogen.GeneratedFile, f *protogen.Field, varName st
 		if fMaxLen > 0 {
 			maxLen = uint32(fMaxLen)
 		}
-	}
-
-	// If the text contains a full URL anywhere in it, reject it. This should help us control spam.
-	if rules.GetRejectUrl() {
-		g.P("if ", s12protoPackage.Ident("RejectURLMatcher"), ".MatchString(", varName, ") {")
-		genErrorStringWithParams(g, varName, string(f.Desc.Name()), "not contain a URL")
-		g.P("}")
 	}
 
 	// Now both minLen and maxLen are set


### PR DESCRIPTION
[UT-5331] When both reject and break url are defined reject takes precedence

<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

<!-- Short summary of what the PR does -->

## Problem description

<!-- Description of the problem being solved -->

## Pros/cons of approach implemented

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [ ] Is this PR a reasonable size?

<!-- If this PR is part of a broader set of changes, please provide a deployment sequence that includes all relevant PRs, so that changes can be reverted in the right order if a rollback were required (e.g. as part of an incident mitigation). To check the box, put an `x` in the box -->

- [ ] List deployment sequence with all relevant PRs.
  - ...

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.


[UT-5331]: https://safetyculture.atlassian.net/browse/UT-5331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ