### PR TITLE
EX-3143: Declare proto3 optional support in protoc-gen-cruxclient

### DIFF
--- a/protobuf/protoc-gen-cruxclient/cruxclient_generator.cc
+++ b/protobuf/protoc-gen-cruxclient/cruxclient_generator.cc
@@ -28,6 +28,10 @@ class Generator : public CodeGenerator {
   Generator() {}
   ~Generator() override {}
 
+  uint64_t GetSupportedFeatures() const override {
+    return FEATURE_PROTO3_OPTIONAL;
+  }
+
   bool Generate(
     const FileDescriptor *file,
     const string &parameter,


### PR DESCRIPTION
## Summary

Adds `GetSupportedFeatures()` override to declare `FEATURE_PROTO3_OPTIONAL` support in the cruxclient protoc plugin.

[EX-3143](https://safetyculture.atlassian.net/browse/EX-3143)

## Problem description

When using `protoc-gen-cruxclient` with proto files that use `optional` fields (proto3 optional), buf/protoc emits warnings like:

```
WARN    plugin "cruxclient" does not support required features.
  Feature "proto3 optional" is required by 28 file(s)
```

The fix is a one-line override in the Generator class to declare the plugin supports this feature.

[EX-3143]: https://safetyculture.atlassian.net/browse/EX-3143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ