### PR TITLE
[FG-8301] Add validator.pii FieldOptions extension

### DIFF
--- a/s12/protobuf/proto/validator.pb.go
+++ b/s12/protobuf/proto/validator.pb.go
@@ -1080,6 +1080,14 @@ var file_s12_protobuf_proto_validator_proto_extTypes = []protoimpl.ExtensionInfo
 		Tag:           "bytes,65223,opt,name=username",
 		Filename:      "s12/protobuf/proto/validator.proto",
 	},
+	{
+		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtensionType: (*bool)(nil),
+		Field:         65224,
+		Name:          "validator.pii",
+		Tag:           "varint,65224,opt,name=pii",
+		Filename:      "s12/protobuf/proto/validator.proto",
+	},
 }
 
 // Extension fields to descriptorpb.FieldOptions.
@@ -1201,6 +1209,15 @@ var (
 	//
 	// optional validator.UsernameRules username = 65223;
 	E_Username = &file_s12_protobuf_proto_validator_proto_extTypes[23]
+	// Marks a field as containing personally identifiable information (PII) —
+	// e.g. email, phone, physical address, legal name. Does not validate or
+	// constrain the field's value; it's metadata for consumers that must not
+	// expose raw PII (e.g. tools whose output reaches an LLM, or automated
+	// integrations without human-in-the-loop review) to redact automatically
+	// via reflection rather than per-type hand-written logic.
+	//
+	// optional bool pii = 65224;
+	E_Pii = &file_s12_protobuf_proto_validator_proto_extTypes[24]
 )
 
 var File_s12_protobuf_proto_validator_proto protoreflect.FileDescriptor
@@ -1416,10 +1433,13 @@ var file_s12_protobuf_proto_validator_proto_rawDesc = []byte{
 	0x69, 0x6f, 0x6e, 0x73, 0x18, 0xc7, 0xfd, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x18, 0x2e, 0x76,
 	0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x2e, 0x55, 0x73, 0x65, 0x72, 0x6e, 0x61, 0x6d,
 	0x65, 0x52, 0x75, 0x6c, 0x65, 0x73, 0x52, 0x08, 0x75, 0x73, 0x65, 0x72, 0x6e, 0x61, 0x6d, 0x65,
-	0x42, 0x37, 0x5a, 0x35, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x53,
-	0x61, 0x66, 0x65, 0x74, 0x79, 0x43, 0x75, 0x6c, 0x74, 0x75, 0x72, 0x65, 0x2f, 0x73, 0x31, 0x32,
-	0x2d, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x31, 0x32, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
-	0x62, 0x75, 0x66, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x3a, 0x31, 0x0a, 0x03, 0x70, 0x69, 0x69, 0x12, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
+	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f,
+	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0xc8, 0xfd, 0x03, 0x20, 0x01, 0x28, 0x08, 0x52, 0x03,
+	0x70, 0x69, 0x69, 0x42, 0x37, 0x5a, 0x35, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
+	0x6d, 0x2f, 0x53, 0x61, 0x66, 0x65, 0x74, 0x79, 0x43, 0x75, 0x6c, 0x74, 0x75, 0x72, 0x65, 0x2f,
+	0x73, 0x31, 0x32, 0x2d, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x31, 0x32, 0x2f, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
 }
 
 var (
@@ -1474,19 +1494,20 @@ var file_s12_protobuf_proto_validator_proto_depIdxs = []int32{
 	9,  // 22: validator.number:extendee -> google.protobuf.FieldOptions
 	9,  // 23: validator.simple_string:extendee -> google.protobuf.FieldOptions
 	9,  // 24: validator.username:extendee -> google.protobuf.FieldOptions
-	4,  // 25: validator.email:type_name -> validator.EmailRules
-	3,  // 26: validator.string:type_name -> validator.StringRules
-	3,  // 27: validator.unsafe_string:type_name -> validator.StringRules
-	5,  // 28: validator.id:type_name -> validator.IdRules
-	6,  // 29: validator.url:type_name -> validator.URLRules
-	7,  // 30: validator.timezone:type_name -> validator.TimezoneRules
-	8,  // 31: validator.number:type_name -> validator.NumberRules
-	1,  // 32: validator.simple_string:type_name -> validator.SimpleStringRules
-	2,  // 33: validator.username:type_name -> validator.UsernameRules
-	34, // [34:34] is the sub-list for method output_type
-	34, // [34:34] is the sub-list for method input_type
-	25, // [25:34] is the sub-list for extension type_name
-	1,  // [1:25] is the sub-list for extension extendee
+	9,  // 25: validator.pii:extendee -> google.protobuf.FieldOptions
+	4,  // 26: validator.email:type_name -> validator.EmailRules
+	3,  // 27: validator.string:type_name -> validator.StringRules
+	3,  // 28: validator.unsafe_string:type_name -> validator.StringRules
+	5,  // 29: validator.id:type_name -> validator.IdRules
+	6,  // 30: validator.url:type_name -> validator.URLRules
+	7,  // 31: validator.timezone:type_name -> validator.TimezoneRules
+	8,  // 32: validator.number:type_name -> validator.NumberRules
+	1,  // 33: validator.simple_string:type_name -> validator.SimpleStringRules
+	2,  // 34: validator.username:type_name -> validator.UsernameRules
+	35, // [35:35] is the sub-list for method output_type
+	35, // [35:35] is the sub-list for method input_type
+	26, // [26:35] is the sub-list for extension type_name
+	1,  // [1:26] is the sub-list for extension extendee
 	0,  // [0:1] is the sub-list for field type_name
 }
 
@@ -1600,7 +1621,7 @@ func file_s12_protobuf_proto_validator_proto_init() {
 			RawDescriptor: file_s12_protobuf_proto_validator_proto_rawDesc,
 			NumEnums:      1,
 			NumMessages:   8,
-			NumExtensions: 24,
+			NumExtensions: 25,
 			NumServices:   0,
 		},
 		GoTypes:           file_s12_protobuf_proto_validator_proto_goTypes,

--- a/s12/protobuf/proto/validator.proto
+++ b/s12/protobuf/proto/validator.proto
@@ -59,6 +59,13 @@ extend google.protobuf.FieldOptions {
   optional SimpleStringRules simple_string = 65222;
   // Validates field as a valid email OR a valid non-email username (compound OR)
   optional UsernameRules username = 65223;
+  // Marks a field as containing personally identifiable information (PII) —
+  // e.g. email, phone, physical address, legal name. Does not validate or
+  // constrain the field's value; it's metadata for consumers that must not
+  // expose raw PII (e.g. tools whose output reaches an LLM, or automated
+  // integrations without human-in-the-loop review) to redact automatically
+  // via reflection rather than per-type hand-written logic.
+  optional bool pii = 65224;
 }
 
 // SymbolCategory defines which special characters (Unicode symbols and the like) are allowed


### PR DESCRIPTION
## What

Adds a new `(validator.pii)` field annotation — pure metadata marking a field as containing personal data (email, phone, physical address, legal name). Unlike every other extension in this file, it does not validate or constrain the field's value.

Jira: [FG-8301](https://safetyculture.atlassian.net/browse/FG-8301)

## Usage

**Declare:**
```proto
string email = 4 [(validator.pii) = true];
```

**Read:**
```go
import (
    "google.golang.org/protobuf/proto"
    "google.golang.org/protobuf/reflect/protoreflect"
    "google.golang.org/protobuf/types/descriptorpb"
    validator "github.com/SafetyCulture/s12-proto/s12/protobuf/proto"
)

func isPII(fd protoreflect.FieldDescriptor) bool {
    opts, ok := fd.Options().(*descriptorpb.FieldOptions)
    if !ok {
        return false
    }
    pii, _ := proto.GetExtension(opts, validator.E_Pii).(bool)
    return pii
}
```

Walk a message's fields via `msg.ProtoReflect().Range(...)`, call `isPII(fd)` on each, and clear/mask the ones that match. That's the pattern our redactor in `api-tools-support-mcp` will use once this merges.

## Changes

**Source**
- `s12/protobuf/proto/validator.proto` — `optional bool pii = 65224;`

**Generated** (regenerated with local protoc 36.0, version-comment stamp reverted to match master's `v7.35.0` — see Reviewer notes)
- `s12/protobuf/proto/validator.pb.go`

No changes to `protobuf/protoc-gen-govalidator/plugin/plugin.go` or `valtest` — see Reviewer notes for why.

## Why this doesn't follow the #157 (validator.username) pattern

Every existing extension in this file drives generated validation — `protoc-gen-govalidator` reads it via `plugin.go`'s `validExts` allowlist and emits `Validate()` logic, exercised by `valtest`. `pii` is deliberately the first extension that isn't a validator: it's descriptive metadata for a downstream consumer (a reflection-based PII redactor in `api-tools-support-mcp`, not yet built), not a constraint on the field's value. So it's intentionally **not** added to `validExts`/`plugin.go`, and there's no `valtest` coverage to add — that machinery only exists to generate validation code, and this extension must generate none.

## Side effects

None.
- Confirmed `pii` isn't in `validExts`/`validNonRepeatedExts` — zero effect on `protoc-gen-govalidator`'s output, including for fields that combine `pii` with an existing validator (e.g. `email` + `pii` on the same field).
- Proto2 extension fields live on the `FieldOptions` descriptor (compile-time schema metadata) — no effect on wire format or serialization of any message.

## Rollout

Unlike #157 (`validator.username`), this does **not** need a `protoc-docker` bump. `S12_PROTO_VERSION` in `protoc-docker` only pins the `protoc-gen-govalidator`/`protoc-gen-s12perm` binaries, and neither reads `pii`. Rollout is just:

1. This PR merges + tags a new `s12-proto` release.
2. [APISchema#9930](https://github.com/SafetyCulture/APISchema/pull/9930) (already vendors `pii` at the same number, 65224) merges, `s12-apis-go` regenerates/publishes.
3. `api-tools-support-mcp` bumps its `s12-proto` and `s12-apis-go` deps and implements the reflection-based redactor that actually reads `E_Pii`.

## Verification

- `go build ./...` ✅
- `go vet ./s12/protobuf/proto/...` ✅
- Regenerated `validator.pb.go` via `make generate`; diff reviewed — adds `E_Pii` only, no unrelated churn

## Reviewer notes

- **protoc version stamp:** regenerated locally with protoc 36.0 (protoc-gen-go pinned to the repo's v1.34.2). Reverted the resulting `protoc v7.36.0` comment-line bump back to master's `v7.35.0` since the descriptor output is otherwise identical — same approach #157 used for its stamp mismatch.
- **Field number:** landed on 65224, not 65223 — 65223 is already `validator.username` (#157) in this repo. APISchema's vendored copy of this file was stale and missing `username` entirely, which is how an earlier draft of this work picked 65223 and collided; fixed in [APISchema#9930](https://github.com/SafetyCulture/APISchema/pull/9930).

[FG-8301]: https://safetyculture.atlassian.net/browse/FG-8301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ