### PR TITLE
[FG-8301] Add validator.redact opt-in alongside validator.pii

### DIFF
--- a/s12/protobuf/proto/validator.pb.go
+++ b/s12/protobuf/proto/validator.pb.go
@@ -1088,6 +1088,14 @@ var file_s12_protobuf_proto_validator_proto_extTypes = []protoimpl.ExtensionInfo
 		Tag:           "varint,65224,opt,name=pii",
 		Filename:      "s12/protobuf/proto/validator.proto",
 	},
+	{
+		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtensionType: (*bool)(nil),
+		Field:         65225,
+		Name:          "validator.redact",
+		Tag:           "varint,65225,opt,name=redact",
+		Filename:      "s12/protobuf/proto/validator.proto",
+	},
 }
 
 // Extension fields to descriptorpb.FieldOptions.
@@ -1210,14 +1218,22 @@ var (
 	// optional validator.UsernameRules username = 65223;
 	E_Username = &file_s12_protobuf_proto_validator_proto_extTypes[23]
 	// Marks a field as containing personally identifiable information (PII) —
-	// e.g. email, phone, physical address, legal name. Does not validate or
-	// constrain the field's value; it's metadata for consumers that must not
-	// expose raw PII (e.g. tools whose output reaches an LLM, or automated
-	// integrations without human-in-the-loop review) to redact automatically
-	// via reflection rather than per-type hand-written logic.
+	// e.g. email, phone, physical address, legal name. Purely descriptive:
+	// does not validate, constrain, or redact the field's value on its own.
+	// Cataloguing a field as PII does not change any consumer's behavior —
+	// pair with (validator.redact) to opt it into automatic redaction.
 	//
 	// optional bool pii = 65224;
 	E_Pii = &file_s12_protobuf_proto_validator_proto_extTypes[24]
+	// Opts a field into automatic redaction by reflection-based consumers
+	// (e.g. RedactPII) — but only when the field is also marked
+	// (validator.pii) = true. A field can be catalogued as PII without this
+	// flag (e.g. for audit/log-scrubbing purposes) without being silently
+	// stripped from every response that happens to call a generic redactor;
+	// setting this is a deliberate, separate opt-in into that behavior.
+	//
+	// optional bool redact = 65225;
+	E_Redact = &file_s12_protobuf_proto_validator_proto_extTypes[25]
 )
 
 var File_s12_protobuf_proto_validator_proto protoreflect.FileDescriptor
@@ -1436,10 +1452,14 @@ var file_s12_protobuf_proto_validator_proto_rawDesc = []byte{
 	0x3a, 0x31, 0x0a, 0x03, 0x70, 0x69, 0x69, 0x12, 0x1d, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f,
 	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0xc8, 0xfd, 0x03, 0x20, 0x01, 0x28, 0x08, 0x52, 0x03,
-	0x70, 0x69, 0x69, 0x42, 0x37, 0x5a, 0x35, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
-	0x6d, 0x2f, 0x53, 0x61, 0x66, 0x65, 0x74, 0x79, 0x43, 0x75, 0x6c, 0x74, 0x75, 0x72, 0x65, 0x2f,
-	0x73, 0x31, 0x32, 0x2d, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x31, 0x32, 0x2f, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x70, 0x69, 0x69, 0x3a, 0x37, 0x0a, 0x06, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x12, 0x1d, 0x2e,
+	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+	0x46, 0x69, 0x65, 0x6c, 0x64, 0x4f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x18, 0xc9, 0xfd, 0x03,
+	0x20, 0x01, 0x28, 0x08, 0x52, 0x06, 0x72, 0x65, 0x64, 0x61, 0x63, 0x74, 0x42, 0x37, 0x5a, 0x35,
+	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x53, 0x61, 0x66, 0x65, 0x74,
+	0x79, 0x43, 0x75, 0x6c, 0x74, 0x75, 0x72, 0x65, 0x2f, 0x73, 0x31, 0x32, 0x2d, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x2f, 0x73, 0x31, 0x32, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f,
+	0x70, 0x72, 0x6f, 0x74, 0x6f,
 }
 
 var (
@@ -1495,19 +1515,20 @@ var file_s12_protobuf_proto_validator_proto_depIdxs = []int32{
 	9,  // 23: validator.simple_string:extendee -> google.protobuf.FieldOptions
 	9,  // 24: validator.username:extendee -> google.protobuf.FieldOptions
 	9,  // 25: validator.pii:extendee -> google.protobuf.FieldOptions
-	4,  // 26: validator.email:type_name -> validator.EmailRules
-	3,  // 27: validator.string:type_name -> validator.StringRules
-	3,  // 28: validator.unsafe_string:type_name -> validator.StringRules
-	5,  // 29: validator.id:type_name -> validator.IdRules
-	6,  // 30: validator.url:type_name -> validator.URLRules
-	7,  // 31: validator.timezone:type_name -> validator.TimezoneRules
-	8,  // 32: validator.number:type_name -> validator.NumberRules
-	1,  // 33: validator.simple_string:type_name -> validator.SimpleStringRules
-	2,  // 34: validator.username:type_name -> validator.UsernameRules
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	26, // [26:35] is the sub-list for extension type_name
-	1,  // [1:26] is the sub-list for extension extendee
+	9,  // 26: validator.redact:extendee -> google.protobuf.FieldOptions
+	4,  // 27: validator.email:type_name -> validator.EmailRules
+	3,  // 28: validator.string:type_name -> validator.StringRules
+	3,  // 29: validator.unsafe_string:type_name -> validator.StringRules
+	5,  // 30: validator.id:type_name -> validator.IdRules
+	6,  // 31: validator.url:type_name -> validator.URLRules
+	7,  // 32: validator.timezone:type_name -> validator.TimezoneRules
+	8,  // 33: validator.number:type_name -> validator.NumberRules
+	1,  // 34: validator.simple_string:type_name -> validator.SimpleStringRules
+	2,  // 35: validator.username:type_name -> validator.UsernameRules
+	36, // [36:36] is the sub-list for method output_type
+	36, // [36:36] is the sub-list for method input_type
+	27, // [27:36] is the sub-list for extension type_name
+	1,  // [1:27] is the sub-list for extension extendee
 	0,  // [0:1] is the sub-list for field type_name
 }
 
@@ -1621,7 +1642,7 @@ func file_s12_protobuf_proto_validator_proto_init() {
 			RawDescriptor: file_s12_protobuf_proto_validator_proto_rawDesc,
 			NumEnums:      1,
 			NumMessages:   8,
-			NumExtensions: 25,
+			NumExtensions: 26,
 			NumServices:   0,
 		},
 		GoTypes:           file_s12_protobuf_proto_validator_proto_goTypes,

--- a/s12/protobuf/proto/validator.proto
+++ b/s12/protobuf/proto/validator.proto
@@ -60,12 +60,18 @@ extend google.protobuf.FieldOptions {
   // Validates field as a valid email OR a valid non-email username (compound OR)
   optional UsernameRules username = 65223;
   // Marks a field as containing personally identifiable information (PII) —
-  // e.g. email, phone, physical address, legal name. Does not validate or
-  // constrain the field's value; it's metadata for consumers that must not
-  // expose raw PII (e.g. tools whose output reaches an LLM, or automated
-  // integrations without human-in-the-loop review) to redact automatically
-  // via reflection rather than per-type hand-written logic.
+  // e.g. email, phone, physical address, legal name. Purely descriptive:
+  // does not validate, constrain, or redact the field's value on its own.
+  // Cataloguing a field as PII does not change any consumer's behavior —
+  // pair with (validator.redact) to opt it into automatic redaction.
   optional bool pii = 65224;
+  // Opts a field into automatic redaction by reflection-based consumers
+  // (e.g. s12-modules-go's shared PII redactor) — but only when the field
+  // is also marked (validator.pii) = true. A field can be catalogued as
+  // PII without this flag (e.g. for audit/log-scrubbing purposes) without
+  // being silently stripped from every response that happens to call a
+  // generic redactor; setting this is a deliberate, separate opt-in.
+  optional bool redact = 65225;
 }
 
 // SymbolCategory defines which special characters (Unicode symbols and the like) are allowed


### PR DESCRIPTION
## Summary
Adds `optional bool redact = 65225;` to `validator.proto`'s `FieldOptions` extension. Splits the previously-merged `pii` (#162) into two independent flags:
- `pii` — purely descriptive metadata for cataloguing/audit purposes (e.g. a future log-scrubbing pass). No behavior on its own.
- `redact` — explicit opt-in for reflection-based redaction. A field must be marked **both** `pii = true` and `redact = true` before a generic redactor clears it.

## Why
Marking a field `pii = true` alone should not silently change behavior for every consumer that happens to call a generic redactor — e.g. a field catalogued as PII for `ts-03`-style log scrubbing shouldn't also start disappearing from tool responses as an unintended side effect. Splitting the flag makes "this contains PII" and "actively strip this" two deliberate, separately-reviewable decisions.

## Follow-up
The actual reflection-based redactor consuming these two flags will live in `s12-modules-go` (not here — `s12-proto` stays scoped to schema/extension declarations), and `APISchema#9930`'s already-merged `pii`-only annotations will need a follow-up to add `redact = true` where active redaction is wanted.

## Side effects
None — same reasoning as #162: neither flag participates in `protoc-gen-govalidator`'s `validExts`, so no generated validation logic changes.

## Test plan
- [x] `buf lint .` — clean
- [x] `go build ./...` / `go vet ./...` — clean
- [x] Regenerated `validator.pb.go` via `make generate`, diff reviewed — adds `E_Redact` only