### PR TITLE
[PEOPLE-41455] Report values admitted only by a widened category class

### DIFF
--- a/protobuf/protoc-gen-csharpvalidator/README.md
+++ b/protobuf/protoc-gen-csharpvalidator/README.md
@@ -78,6 +78,12 @@ Both are reproduced. Narrowing them here would reject requests the Go validators
 is a change to live traffic and needs its own measurement and rollout rather than arriving with a
 language port.
 
+The category widening is also observed. Alongside the class that decides the verdict, the generator
+emits the class the annotation asks for, and a value admitted only by the wider of the two is passed
+to `ValidationLog.Report` with the requirement `value must only have characters in the declared
+categories`. Validation still succeeds. With no handler attached the report is discarded, so the
+measurement that a narrowing needs can be gathered by setting one.
+
 Three encoding messages repeat the word "must": `value must must be normalisable to NFC`,
 `value must must have valid encoding`, and `value must must be a valid UTF-8-encoded string`. The C#
 emitter writes them the same way.

--- a/protobuf/protoc-gen-csharpvalidator/conformance/Program.cs
+++ b/protobuf/protoc-gen-csharpvalidator/conformance/Program.cs
@@ -34,6 +34,7 @@ internal static class Program
         CheckFields(directory, corpus, report);
         CheckNestedFields(directory, corpus, report);
         CheckDeepNesting(directory, corpus, report);
+        CheckCategoryObservation(directory, report);
 
         return report.Summarise(corpus);
     }
@@ -370,6 +371,56 @@ internal static class Program
 
     private static FieldDescriptor FieldByName(IMessage message, string name) =>
         message.Descriptor.Fields.InDeclarationOrder().First(f => f.Name == name);
+
+    /// <summary>
+    /// Checks the second reading of a widened character class, which reports through
+    /// <see cref="ValidationLog"/> without changing the verdict.
+    /// </summary>
+    /// <remarks>
+    /// symbol_string declares symbols: [CURRENCY]. Go has no counterpart to compare against, so
+    /// this asserts against the declaration rather than against a recorded vector.
+    /// </remarks>
+    private static void CheckCategoryObservation(string directory, Report report)
+    {
+        var cases = new (string Name, string Value, bool WantReport)[]
+        {
+            ("currency", "Accept $ £ ¥ €", false),
+            ("mathSymbol", "Accept <", true),
+            ("pipe", "Accept |", true),
+            ("otherSymbol", "Accept ©", true),
+            ("modifier", "Accept ^", true),
+        };
+
+        var reported = new List<string>();
+        ValidationLog.Handler = (field, requirement, _) =>
+        {
+            if (field == "symbol_string")
+            {
+                reported.Add(requirement);
+            }
+        };
+
+        try
+        {
+            foreach (var (name, value, wantReport) in cases)
+            {
+                var message = BaseMessage(directory);
+                message.SymbolString = value;
+
+                reported.Clear();
+                var error = message.Validate();
+
+                report.Compare("observation", name, "accepted", true, error is null);
+                report.Compare("observation", name, "reported", wantReport, reported.Count == 1);
+            }
+        }
+        finally
+        {
+            ValidationLog.Handler = null;
+        }
+
+        report.Counted("observation", cases.Length);
+    }
 
     /// <summary>The message every field record starts from.</summary>
     private static ValTestMessage BaseMessage(string directory) =>

--- a/protobuf/protoc-gen-csharpvalidator/conformance/generated/ValtestValidator.g.cs
+++ b/protobuf/protoc-gen-csharpvalidator/conformance/generated/ValtestValidator.g.cs
@@ -212,6 +212,10 @@ namespace Valtest
             {
                 return ValidationError.Create("rune_string", "value must only have valid characters");
             }
+            else if (!CharacterClass.IsMatch(ValtestValidatorClasses.Classcd31dc1cb28f24ab, RuneString, UnicodeCategories.L | UnicodeCategories.N | UnicodeCategories.So))
+            {
+                ValidationLog.Report("rune_string", "value must only have characters in the declared categories", ValidatorHelpers.TruncateAndEncode(RuneString, 50));
+            }
             if (StringMutators.TryNormalizeToNfc(ReplaceString, out var _nfc20))
             {
                 ReplaceString = _nfc20;
@@ -314,6 +318,10 @@ namespace Valtest
             {
                 return ValidationError.Create("symbol_string", "value must only have valid characters");
             }
+            else if (!CharacterClass.IsMatch(ValtestValidatorClasses.Classaf971ef2dbc5d5ad, SymbolString, UnicodeCategories.L | UnicodeCategories.N | UnicodeCategories.Sc))
+            {
+                ValidationLog.Report("symbol_string", "value must only have characters in the declared categories", ValidatorHelpers.TruncateAndEncode(SymbolString, 50));
+            }
             if (StringMutators.TryNormalizeToNfc(SymbolsString, out var _nfc28))
             {
                 SymbolsString = _nfc28;
@@ -338,6 +346,10 @@ namespace Valtest
             if (!CharacterClass.IsMatch(ValtestValidatorClasses.Classb854df56e032183c, SymbolsString, UnicodeCategories.L | UnicodeCategories.M | UnicodeCategories.N | UnicodeCategories.S))
             {
                 return ValidationError.Create("symbols_string", "value must only have valid characters");
+            }
+            else if (!CharacterClass.IsMatch(ValtestValidatorClasses.Classf7befb9add8afcce, SymbolsString, UnicodeCategories.L | UnicodeCategories.M | UnicodeCategories.N | UnicodeCategories.So))
+            {
+                ValidationLog.Report("symbols_string", "value must only have characters in the declared categories", ValidatorHelpers.TruncateAndEncode(SymbolsString, 50));
             }
             if (StringMutators.TryNormalizeToNfc(NewlineString, out var _nfc30))
             {
@@ -455,6 +467,10 @@ namespace Valtest
             {
                 return ValidationError.Create("all_string", "value must only have valid characters");
             }
+            else if (!CharacterClass.IsMatch(ValtestValidatorClasses.Classde30976ea91546b8, AllString, UnicodeCategories.L | UnicodeCategories.M | UnicodeCategories.N | UnicodeCategories.Po | UnicodeCategories.Sc | UnicodeCategories.Sk | UnicodeCategories.Sm | UnicodeCategories.So))
+            {
+                ValidationLog.Report("all_string", "value must only have characters in the declared categories", ValidatorHelpers.TruncateAndEncode(AllString, 50));
+            }
             if (Name != "")
             {
                 if (StringMutators.TryNormalizeToNfc(Name, out var _nfc40))
@@ -543,6 +559,10 @@ namespace Valtest
                 if (!CharacterClass.IsMatch(ValtestValidatorClasses.Classa288868e5c1e56c0, ScPermissive, UnicodeCategories.L | UnicodeCategories.M | UnicodeCategories.N | UnicodeCategories.P | UnicodeCategories.S))
                 {
                     return ValidationError.Create("sc_permissive", "value must only have valid characters");
+                }
+                else if (!CharacterClass.IsMatch(ValtestValidatorClasses.Classe05c064070025fac, ScPermissive, UnicodeCategories.L | UnicodeCategories.M | UnicodeCategories.N | UnicodeCategories.Po | UnicodeCategories.Sc | UnicodeCategories.Sk | UnicodeCategories.Sm | UnicodeCategories.So))
+                {
+                    ValidationLog.Report("sc_permissive", "value must only have characters in the declared categories", ValidatorHelpers.TruncateAndEncode(ScPermissive, 50));
                 }
             }
             if (NotSanitisePua != "")
@@ -1205,6 +1225,10 @@ namespace Valtest
             if (!CharacterClass.IsMatch(ValtestValidatorClasses.Class378107c94d466995, Name, UnicodeCategories.L | UnicodeCategories.M | UnicodeCategories.N | UnicodeCategories.P | UnicodeCategories.S))
             {
                 return ValidationError.Create("name", "value must only have valid characters");
+            }
+            else if (!CharacterClass.IsMatch(ValtestValidatorClasses.Class74440f7ecadc7208, Name, UnicodeCategories.L | UnicodeCategories.M | UnicodeCategories.N | UnicodeCategories.Po | UnicodeCategories.Sc | UnicodeCategories.Sk | UnicodeCategories.Sm | UnicodeCategories.So))
+            {
+                ValidationLog.Report("name", "value must only have characters in the declared categories", ValidatorHelpers.TruncateAndEncode(Name, 50));
             }
             if (Latitude != 0)
             {
@@ -1986,13 +2010,19 @@ namespace Valtest
 
         internal static readonly Regex Class36943bf8f0f20d3d = new(@"\A[\p{L}\p{N}\p{S}o\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u200D\u2013]+\z", Options);
 
+        internal static readonly Regex Classcd31dc1cb28f24ab = new(@"\A[\p{L}\p{N}\p{So}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u200D\u2013]+\z", Options);
+
         internal static readonly Regex Classb0d9998644e4afc5 = new(@"\A[\p{L}\p{N}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u02C2\u02C3\u037E\u2013\u2019\u201D\u2052\u2212\u2215\u2217\u2E40\uFF01\uFF0B\uFF3C\uFFE8]+\z", Options);
 
         internal static readonly Regex Class2f2809e3638980be = new(@"\A[\p{L}\p{N}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u007E\u00BF\u2013]+\z", Options);
 
         internal static readonly Regex Classb81e5a62415961a0 = new(@"\A[\p{L}\p{N}\p{S}c\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u2013]+\z", Options);
 
+        internal static readonly Regex Classaf971ef2dbc5d5ad = new(@"\A[\p{L}\p{N}\p{Sc}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u2013]+\z", Options);
+
         internal static readonly Regex Classb854df56e032183c = new(@"\A[\p{L}\p{M}\p{N}\p{S}o\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u200D\u2013]+\z", Options);
+
+        internal static readonly Regex Classf7befb9add8afcce = new(@"\A[\p{L}\p{M}\p{N}\p{So}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u200D\u2013]+\z", Options);
 
         internal static readonly Regex Class967d66b5da32f455 = new(@"\A[\p{L}\p{N}\u000A\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u2013]+\z", Options);
 
@@ -2000,15 +2030,21 @@ namespace Valtest
 
         internal static readonly Regex Classae5e5e7fe569f8e8 = new(@"\A[\p{L}\p{M}\p{N}\p{P}o\p{S}c\p{S}k\p{S}m\p{S}o\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u007E\u00BF\u02C3\u104B\u200D\u2013\u2018\u2019\u201C\u201D\u2022\uFFFD}]+\z", Options);
 
+        internal static readonly Regex Classde30976ea91546b8 = new(@"\A[\p{L}\p{M}\p{N}\p{Po}\p{Sc}\p{Sk}\p{Sm}\p{So}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u007E\u00BF\u02C3\u104B\u200D\u2013\u2018\u2019\u201C\u201D\u2022\uFFFD}]+\z", Options);
+
         internal static readonly Regex Class9df32b727a2de410 = new(@"\A[\p{L}\p{N}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u00BF\u2013\u2019\u2212]+\z", Options);
 
         internal static readonly Regex Classa288868e5c1e56c0 = new(@"\A[\p{L}\p{M}\p{N}\p{P}o\p{S}c\p{S}k\p{S}m\p{S}o\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u007E\u00BF\u02C2\u02C3\u037E\u104B\u200D\u2013\u2018\u2019\u201C\u201D\u2022\u2052\u2212\u2215\u2217\u2E40\uFF01\uFF0B\uFF3C\uFFE8}]+\z", Options);
+
+        internal static readonly Regex Classe05c064070025fac = new(@"\A[\p{L}\p{M}\p{N}\p{Po}\p{Sc}\p{Sk}\p{Sm}\p{So}\u0020\u0028\u0029\u002C\u002E\u003A\u003F\u0040\u005B\u005D\u005F\u007E\u00BF\u02C2\u02C3\u037E\u104B\u200D\u2013\u2018\u2019\u201C\u201D\u2022\u2052\u2212\u2215\u2217\u2E40\uFF01\uFF0B\uFF3C\uFFE8}]+\z", Options);
 
         internal static readonly Regex Class5661fb990bb10882 = new(@"\A[\p{L}\p{N}\u0020\u0021\u0022\u0023\u0025\u0026\u0027\u0028\u0029\u002A\u002C\u002D\u002E\u002F\u003A\u003F\u0040\u005B\u005C\u005D\u005F\u00BF\u2013]+\z", Options);
 
         internal static readonly Regex Class235a0979cf68a1e9 = new(@"\A[\p{L}\p{N}\u000A\u0020\u0021\u0022\u0023\u0025\u0026\u0027\u0028\u0029\u002A\u002C\u002D\u002E\u002F\u003A\u003F\u0040\u005B\u005C\u005D\u005F\u00BF\u2013]+\z", Options);
 
         internal static readonly Regex Class378107c94d466995 = new(@"\A[\p{L}\p{M}\p{N}\p{P}o\p{S}c\p{S}k\p{S}m\p{S}o\u0020\u0021\u0022\u0023\u0025\u0026\u0027\u0028\u0029\u002A\u002C\u002D\u002E\u002F\u003A\u003F\u0040\u005B\u005C\u005D\u005F\u007E\u00BF\u104B\u200D\u2013\u2018\u2019\u201C\u201D\u2022]+\z", Options);
+
+        internal static readonly Regex Class74440f7ecadc7208 = new(@"\A[\p{L}\p{M}\p{N}\p{Po}\p{Sc}\p{Sk}\p{Sm}\p{So}\u0020\u0021\u0022\u0023\u0025\u0026\u0027\u0028\u0029\u002A\u002C\u002D\u002E\u002F\u003A\u003F\u0040\u005B\u005C\u005D\u005F\u007E\u00BF\u104B\u200D\u2013\u2018\u2019\u201C\u201D\u2022]+\z", Options);
 
         internal static readonly Regex Class64175c84ea576c31 = new(@"\A(([0-9])+-([0-9a-f]){32})?\z", Options);
     }

--- a/protobuf/protoc-gen-csharpvalidator/plugin/pattern.go
+++ b/protobuf/protoc-gen-csharpvalidator/plugin/pattern.go
@@ -18,6 +18,29 @@ type translatedPattern struct {
 	// point above the Basic Multilingual Plane never matches the category token that
 	// admits it; the runtime removes those before matching instead.
 	AstralCategories []string
+
+	// NarrowPattern reads each two-letter category token as the category it names,
+	// and is empty when the class holds no such token. It admits a subset of
+	// Pattern, and reports rather than decides: a value it turns away has
+	// characters the field's annotation did not ask for.
+	NarrowPattern string
+
+	// NarrowAstralCategories is AstralCategories for NarrowPattern.
+	NarrowAstralCategories []string
+}
+
+// twoLetterCategories are the Unicode general category names written with two
+// letters. A token is only read as one of these when both letters spell a
+// category, so a class member that merely follows a one-letter token stays a
+// literal.
+var twoLetterCategories = map[string]bool{
+	"Lu": true, "Ll": true, "Lt": true, "Lm": true, "Lo": true,
+	"Mn": true, "Mc": true, "Me": true,
+	"Nd": true, "Nl": true, "No": true,
+	"Pc": true, "Pd": true, "Ps": true, "Pe": true, "Pi": true, "Pf": true, "Po": true,
+	"Sm": true, "Sc": true, "Sk": true, "So": true,
+	"Zs": true, "Zl": true, "Zp": true,
+	"Cc": true, "Cf": true, "Cs": true, "Co": true, "Cn": true,
 }
 
 // translatePattern rewrites a generated Go character-class pattern for .NET.
@@ -31,7 +54,9 @@ type translatedPattern struct {
 //   - RE2 reads \pXy as the one-letter class \pX followed by a literal y, so a
 //     declared two-letter category is already the whole one-letter class in Go. That
 //     is reproduced rather than corrected: the generated C# has to accept what the
-//     Go validators accept, and narrowing it here would reject live traffic.
+//     Go validators accept, and narrowing it here would reject live traffic. The
+//     reading the annotation asks for comes back as NarrowPattern, which reports
+//     what it would have turned away without changing the verdict.
 //   - .NET rejects an escape it does not define, such as \_, where RE2 allows any
 //     punctuation to be escaped.
 func translatePattern(goPattern string) (translatedPattern, error) {
@@ -44,9 +69,19 @@ func translatePattern(goPattern string) (translatedPattern, error) {
 		return translatedPattern{}, fmt.Errorf("pattern does not close with ]+$: %s", goPattern)
 	}
 
-	var out strings.Builder
+	var out, narrow strings.Builder
 	seen := map[string]bool{}
-	var categories []string
+	narrowSeen := map[string]bool{}
+	var categories, narrowCategories []string
+	widened := false
+
+	collect := func(category string, into *[]string, seen map[string]bool) {
+		if seen[category] {
+			return
+		}
+		seen[category] = true
+		*into = append(*into, category)
+	}
 
 	for i := 0; i < len(body); {
 		switch {
@@ -67,29 +102,47 @@ func translatePattern(goPattern string) (translatedPattern, error) {
 				return translatedPattern{}, fmt.Errorf("code point U+%X is above the Basic Multilingual Plane and cannot be a character class member", code)
 			}
 			fmt.Fprintf(&out, `\u%04X`, code)
+			fmt.Fprintf(&narrow, `\u%04X`, code)
 			i += end + 1
 
 		case strings.HasPrefix(body[i:], `\p`) && i+2 < len(body) && isCategoryLetter(body[i+2]):
 			// RE2 takes exactly one letter here; anything after it is a literal.
 			category := string(body[i+2])
-			fmt.Fprintf(&out, `\p{%s}`, category)
-			if !seen[category] {
-				seen[category] = true
-				categories = append(categories, category)
+			consumed := 3
+
+			narrowCategory := category
+			if i+3 < len(body) && isCategoryLetter(body[i+3]) && twoLetterCategories[category+string(body[i+3])] {
+				narrowCategory = category + string(body[i+3])
+				consumed = 4
+				widened = true
+				fmt.Fprintf(&out, `\p{%s}`, category)
+				out.WriteString(escapeClassMember(rune(body[i+3])))
+			} else {
+				fmt.Fprintf(&out, `\p{%s}`, category)
 			}
-			i += 3
+			fmt.Fprintf(&narrow, `\p{%s}`, narrowCategory)
+
+			collect(category, &categories, seen)
+			collect(narrowCategory, &narrowCategories, narrowSeen)
+			i += consumed
 
 		default:
 			r, size := decodeRune(body[i:])
 			out.WriteString(escapeClassMember(r))
+			narrow.WriteString(escapeClassMember(r))
 			i += size
 		}
 	}
 
-	return translatedPattern{
+	translated := translatedPattern{
 		Pattern:          `\A[` + out.String() + `]+\z`,
 		AstralCategories: categories,
-	}, nil
+	}
+	if widened {
+		translated.NarrowPattern = `\A[` + narrow.String() + `]+\z`
+		translated.NarrowAstralCategories = narrowCategories
+	}
+	return translated, nil
 }
 
 func isCategoryLetter(b byte) bool {

--- a/protobuf/protoc-gen-csharpvalidator/plugin/pattern_test.go
+++ b/protobuf/protoc-gen-csharpvalidator/plugin/pattern_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 SafetyCulture Pty Ltd. All Rights Reserved.
+
+package plugin
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestTranslatePatternNarrowsTwoLetterCategories covers the second reading of a
+// class holding a two-letter category token: the token names the category, and
+// the letter that the widened reading leaves behind as a literal is part of it.
+func TestTranslatePatternNarrowsTwoLetterCategories(t *testing.T) {
+	tests := []struct {
+		name             string
+		goPattern        string
+		wantPattern      string
+		wantCategories   []string
+		wantNarrow       string
+		wantNarrowCatgys []string
+	}{
+		{
+			name:             "CurrencyWidensToEverySymbol",
+			goPattern:        `^[\pL\pN\pSc\x{0020}]+$`,
+			wantPattern:      `\A[\p{L}\p{N}\p{S}c\u0020]+\z`,
+			wantCategories:   []string{"L", "N", "S"},
+			wantNarrow:       `\A[\p{L}\p{N}\p{Sc}\u0020]+\z`,
+			wantNarrowCatgys: []string{"L", "N", "Sc"},
+		},
+		{
+			name:             "PunctuationAndSymbolTokensTogether",
+			goPattern:        `^[\pM\pPo\pSk\x{2013}]+$`,
+			wantPattern:      `\A[\p{M}\p{P}o\p{S}k\u2013]+\z`,
+			wantCategories:   []string{"M", "P", "S"},
+			wantNarrow:       `\A[\p{M}\p{Po}\p{Sk}\u2013]+\z`,
+			wantNarrowCatgys: []string{"M", "Po", "Sk"},
+		},
+		{
+			name:           "OneLetterTokensAreAlreadyWhatTheyName",
+			goPattern:      `^[\pL\pN\x{0020}]+$`,
+			wantPattern:    `\A[\p{L}\p{N}\u0020]+\z`,
+			wantCategories: []string{"L", "N"},
+			wantNarrow:     "",
+		},
+		{
+			name:           "LetterAfterATokenIsNotAlwaysACategory",
+			goPattern:      `^[\pLz]+$`,
+			wantPattern:    `\A[\p{L}z]+\z`,
+			wantCategories: []string{"L"},
+			wantNarrow:     "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := translatePattern(tc.goPattern)
+			if err != nil {
+				t.Fatalf("translatePattern(%q) = %v", tc.goPattern, err)
+			}
+			if got.Pattern != tc.wantPattern {
+				t.Errorf("Pattern = %q, want %q", got.Pattern, tc.wantPattern)
+			}
+			if !slices.Equal(got.AstralCategories, tc.wantCategories) {
+				t.Errorf("AstralCategories = %v, want %v", got.AstralCategories, tc.wantCategories)
+			}
+			if got.NarrowPattern != tc.wantNarrow {
+				t.Errorf("NarrowPattern = %q, want %q", got.NarrowPattern, tc.wantNarrow)
+			}
+			if !slices.Equal(got.NarrowAstralCategories, tc.wantNarrowCatgys) {
+				t.Errorf("NarrowAstralCategories = %v, want %v", got.NarrowAstralCategories, tc.wantNarrowCatgys)
+			}
+		})
+	}
+}

--- a/protobuf/protoc-gen-csharpvalidator/plugin/steps.go
+++ b/protobuf/protoc-gen-csharpvalidator/plugin/steps.go
@@ -315,11 +315,25 @@ func emitStringOp(e *emitter, f *plan.Field, op plan.Op, value, holder string) e
 		fail(e, f, o.LogOnly, value, "value must only have valid characters")
 		e.shut()
 
+		if translated.NarrowPattern != "" {
+			narrowName := e.pattern(translated.NarrowPattern)
+			e.open("else if (!CharacterClass.IsMatch(", holder, ".", narrowName, ", ", value, ", ",
+				astralExpression(translated.NarrowAstralCategories), "))")
+			e.p("ValidationLog.Report(", quote(f.Name), ", ", quote(narrowRequirement), ", ",
+				"ValidatorHelpers.TruncateAndEncode(", stringify(f, value), ", ", logOnlyMaxLength, "));")
+			e.shut()
+		}
+
 	default:
 		return fmt.Errorf("no C# emitter for string operation %T", op)
 	}
 	return nil
 }
+
+// narrowRequirement is reported for a value the class admits only because a
+// two-letter category token widened to its one-letter class. Validation passes;
+// the line records that the value carries characters the field did not declare.
+const narrowRequirement = "value must only have characters in the declared categories"
 
 // astralExpression names the categories whose code points above the Basic
 // Multilingual Plane the pattern is meant to admit.


### PR DESCRIPTION
## Summary

Adds a second character class to the generated C# validators — the one the annotation declares —
and reports through `ValidationLog` when a value is admitted only by the wider class that decides
the verdict.

[PEOPLE-41455](https://safetyculture.atlassian.net/browse/PEOPLE-41455)

No verdict changes. With no handler attached the report is discarded, so a service opts in to the
measurement by attaching one.

Top of the stack: #159, then #164, then this.

## Problem description

The generator writes a Unicode general category into a character class as `\pSc`. RE2 reads `\pX` as
taking exactly one letter, so that parses as the one-letter class `\pS` followed by a literal `c`,
and compiles without error:

```
[\pSc]    -> [\$\+<->\^`c\|~¢-¦¨©¬®-±´¸×÷ … 🀀-🯊]     all of \pS, plus a literal "c"
[\p{Sc}]  -> [\$¢-¥֏؋߾߿৲৳৻૱௹฿៛₠-⃀꠸﷼﹩＄￠￡￥￦𑿝-𑿠𞋿𞲰]   the currency signs
```

A field declaring `symbols: [CURRENCY]` is checked against every symbol category, and
`symbols: [PUNCTUATION]` reaches every punctuation category the same way.

Correcting the token narrows what the validators accept on every service at once. That is not
justifiable without knowing what it would turn away, and nothing measures that today. This adds the
measurement.

## Why the measurement is the deliverable

The reported values carry two different problems, and only reading real traffic separates them:

- Characters no field wants, which the widening lets in — `<`, `|`, `` ` `` under `symbols: [CURRENCY]`.
- Characters fields do want and no category declares — `Ps`/`Pe` brackets, `Pd` dashes, `Pi`/`Pf`
  quotes. `symbols: [PUNCTUATION]` declares only `Po` and `Sm`, so a fullwidth `）` in a CJK title
  reaches the field solely through `\pP`.

Both surface as "admitted only by the wider class". Correcting the token without first sorting the
reported values into those two buckets would reject the second along with the first.

## What the generator emits

For a class where a two-letter token widened:

```csharp
if (!CharacterClass.IsMatch(Classb81e…, SymbolString, L | N | S))
{
    return ValidationError.Create("symbol_string", "value must only have valid characters");
}
else if (!CharacterClass.IsMatch(Classaf97…, SymbolString, L | N | Sc))
{
    ValidationLog.Report("symbol_string", "value must only have characters in the declared categories", …);
}
```

`\p{S}c` decides, `\p{Sc}` reports. A class with no two-letter token gets no second class and no
branch, so this is inert wherever the defect does not apply — in `s12/training`, for instance, only
`coursebuilder/courses.proto` produces any.

## Testing

- `pattern_test.go` covers the translation: currency widening, two tokens in one class, one-letter
  tokens producing no second pattern, and `\pLz` — where `Lz` is not a general category, so the `z`
  stays a literal and nothing is emitted.
- The conformance runner grows an `observation` group and now checks 10,404 records, still matching
  Go on every one. The five new cases assert both halves: `$ £ ¥ €` accepted with no report,
  `< | © ^` accepted *and* reported.

## Pros/cons of approach implemented

- The measurement comes from the same generator as the rule, so it cannot describe a class the
  validators do not actually use.
- Nothing changes until someone attaches a handler, so it can ship ahead of any decision about
  narrowing.
- It emits a second `Regex` per affected class. The classes are static readonly and only built where
  a two-letter token appears, but it is not free.

## Checklist

- [x] Is this PR a reasonable size?

- [x] List deployment sequence with all relevant PRs.
  - #159, then #164, then this.

- [x] For breaking changes: I have confirmed that other repos are not
  affected, or I have planned a deployment sequence to address any impact.
  - Not a breaking change: verdicts are unchanged in both languages.

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be
  blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try
  to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of
  test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone
  who is.


[PEOPLE-41455]: https://safetyculture.atlassian.net/browse/PEOPLE-41455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ